### PR TITLE
Vector shader: nvidia 1650 support test

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -20,10 +20,11 @@ jobs:
         VERSION_FILE="src/resources/version.h"
         echo "Reading version from $VERSION_FILE"
 
-        version_line=$(grep '#define VERSION_STRING' "$VERSION_FILE")
-        echo "Found line: $version_line"
+        VERSION_MAJOR=$(grep '#define VERSION_MAJOR' "$VERSION_FILE" | awk '{print $3}')
+        VERSION_MINOR=$(grep '#define VERSION_MINOR' "$VERSION_FILE" | awk '{print $3}')
+        VERSION_PATCH=$(grep '#define VERSION_PATCH' "$VERSION_FILE" | awk '{print $3}')
 
-        version=$(echo "$version_line" | sed -E 's/#define VERSION_STRING +"([^"]+)"/\1/')
+        version="${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
         echo "Parsed version: $version"
 
         echo "version=$version" >> $GITHUB_OUTPUT

--- a/MGSHDFix.vcxproj
+++ b/MGSHDFix.vcxproj
@@ -27,6 +27,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\resources\config.cpp" />
     <ClCompile Include="external\safetyhook\src\allocator.cpp" />
     <ClCompile Include="external\safetyhook\src\easy.cpp" />
     <ClCompile Include="external\safetyhook\src\inline_hook.cpp" />
@@ -66,6 +67,7 @@
     <ClCompile Include="src\features\stat_persistence.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\resources\config.hpp" />
     <ClInclude Include="external\safetyhook\include\safetyhook.hpp" />
     <ClInclude Include="src\resources\gpu_check.hpp" />
     <ClInclude Include="src\resources\logging.hpp" />
@@ -73,7 +75,6 @@
     <ClInclude Include="src\fixes\aiming_after_equip.hpp" />
     <ClInclude Include="src\fixes\color_filters.hpp" />
     <ClInclude Include="src\resources\RegStateHelpers.hpp" />
-    <ClInclude Include="src\resources\resource.h" />
     <ClInclude Include="src\resources\version_checking.hpp" />
     <ClInclude Include="src\resources\version.h" />
     <ClInclude Include="src\warnings\corrupt_save_message.hpp" />

--- a/MGSHDFix.vcxproj.filters
+++ b/MGSHDFix.vcxproj.filters
@@ -110,6 +110,9 @@
     <ClCompile Include="src\features\stat_persistence.cpp">
       <Filter>Features</Filter>
     </ClCompile>
+    <ClCompile Include="src\resources\config.cpp">
+      <Filter>Config</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\fixes\line_scaling.hpp">
@@ -205,14 +208,14 @@
     <ClInclude Include="src\resources\RegStateHelpers.hpp">
       <Filter>Utility</Filter>
     </ClInclude>
-    <ClInclude Include="src\resources\resource.h">
-      <Filter>Resources</Filter>
-    </ClInclude>
     <ClInclude Include="src\resources\steam_achievements.hpp">
       <Filter>APIs\Headers</Filter>
     </ClInclude>
     <ClInclude Include="src\features\stat_persistence.hpp">
       <Filter>Features\Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="src\resources\config.hpp">
+      <Filter>Config</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -267,6 +270,9 @@
     </Filter>
     <Filter Include="APIs\Headers">
       <UniqueIdentifier>{a3100db6-b5f8-4b1a-96dc-23576666050c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Config">
+      <UniqueIdentifier>{cd1768eb-087f-41c0-a320-8702dca4749f}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -62,7 +62,7 @@ HWND WINAPI CreateWindowExA_hooked(DWORD dwExStyle, LPCSTR lpClassName, LPCSTR l
         {
             auto hWnd = CreateWindowExA_hook.stdcall<HWND>(dwExStyle, lpClassName, lpWindowName, WS_POPUP, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
             SetWindowPos(hWnd, HWND_TOP, 0, 0, DesktopDimensions.first, DesktopDimensions.second, NULL);
-            spdlog::info("CreateWindowExA: Borderless: ClassName = {}, WindowName = {}, dwStyle = {:x}, X = {}, Y = {}, nWidth = {}, nHeight = {}", lpClassName, lpWindowName, WS_POPUP, X, Y, nWidth, nHeight);
+            spdlog::info("CreateWindowExA: Borderless: ClassName = {}, WindowName = {}, dwStyle = 0x{:08X}, X = {}, Y = {}, nWidth = {}, nHeight = {}", lpClassName, lpWindowName, WS_POPUP, X, Y, nWidth, nHeight);
             spdlog::info("CreateWindowExA: Borderless: SetWindowPos to X = {}, Y = {}, cx = {}, cy = {}", 0, 0, (int)DesktopDimensions.first, (int)DesktopDimensions.second);
             g_D3D11Hooks.MainHwnd = hWnd;
             return hWnd;
@@ -72,7 +72,7 @@ HWND WINAPI CreateWindowExA_hooked(DWORD dwExStyle, LPCSTR lpClassName, LPCSTR l
         {
             auto hWnd = CreateWindowExA_hook.stdcall<HWND>(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
             SetWindowPos(hWnd, HWND_TOP, 0, 0, iOutputResX, iOutputResY, NULL);
-            spdlog::info("CreateWindowExA: Windowed: ClassName = {}, WindowName = {}, dwStyle = {:x}, X = {}, Y = {}, nWidth = {}, nHeight = {}", lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight);
+            spdlog::info("CreateWindowExA: Windowed: ClassName = {}, WindowName = {}, dwStyle = 0x{:08X}, X = {}, Y = {}, nWidth = {}, nHeight = {}", lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight);
             spdlog::info("CreateWindowExA: Windowed: SetWindowPos to X = {}, Y = {}, cx = {}, cy = {}", 0, 0, iOutputResX, iOutputResY);
             g_D3D11Hooks.MainHwnd = hWnd;
             return hWnd;
@@ -454,7 +454,7 @@ static void Init_AspectFOVFix()
         if (uint8_t* MGS3_GameplayAspectScanResult = Memory::PatternScan(baseModule, "F3 0F ?? ?? E8 ?? ?? ?? ?? 48 8D ?? ?? ?? ?? ?? F3 0F ?? ?? ?? ?? ?? ??", "MGS 3: Aspect Ratio"))
         {
             DWORD64 MGS3_GameplayAspectAddress = Memory::GetAbsolute((uintptr_t)MGS3_GameplayAspectScanResult + 0x5);
-            spdlog::info("MGS 3: Aspect Ratio: Function address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)MGS3_GameplayAspectAddress - (uintptr_t)baseModule);
+            spdlog::info("MGS 3: Aspect Ratio: Function address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)MGS3_GameplayAspectAddress - (uintptr_t)baseModule);
 
             static SafetyHookMid MGS3_GameplayAspectMidHook{};
             MGS3_GameplayAspectMidHook = safetyhook::create_mid(MGS3_GameplayAspectAddress + 0x38,
@@ -472,7 +472,7 @@ static void Init_AspectFOVFix()
         if (uint8_t* MGS2_GameplayAspectScanResult = Memory::PatternScan(baseModule, "48 8D ?? ?? ?? E8 ?? ?? ?? ?? E8 ?? ?? ?? ?? F3 44 ?? ?? ?? ?? ?? ?? ??", "MGS 2: Aspect Ratio"))
         {
             DWORD64 MGS2_GameplayAspectAddress = Memory::GetAbsolute((uintptr_t)MGS2_GameplayAspectScanResult + 0xB);
-            spdlog::info("MGS 2: Aspect Ratio: Function address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)MGS2_GameplayAspectAddress - (uintptr_t)baseModule);
+            spdlog::info("MGS 2: Aspect Ratio: Function address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)MGS2_GameplayAspectAddress - (uintptr_t)baseModule);
 
             static SafetyHookMid MGS2_GameplayAspectMidHook{};
             MGS2_GameplayAspectMidHook = safetyhook::create_mid(MGS2_GameplayAspectAddress + 0x38,
@@ -531,7 +531,7 @@ static void Init_HUDFix()
         uint8_t* MGS2_HUDWidthScanResult = Memory::PatternScanSilent(baseModule, "E9 ?? ?? ?? ?? F3 0F ?? ?? ?? 0F ?? ?? F3 0F ?? ?? ?? F3 0F ?? ??");
         if (MGS2_HUDWidthScanResult)
         {
-            spdlog::info("MGS 2: HUD: Address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)MGS2_HUDWidthScanResult - (uintptr_t)baseModule);
+            spdlog::info("MGS 2: HUD: Address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)MGS2_HUDWidthScanResult - (uintptr_t)baseModule);
 
             static SafetyHookMid MGS2_HUDWidthMidHook{};
             MGS2_HUDWidthMidHook = safetyhook::create_mid(MGS2_HUDWidthScanResult + 0xD,
@@ -562,7 +562,7 @@ static void Init_HUDFix()
         {
             // Radar width
             DWORD64 MGS2_RadarWidthAddress = (uintptr_t)MGS2_RadarWidthScanResult;
-            spdlog::info("MGS 2: Radar Width: Hook address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)MGS2_RadarWidthAddress - (uintptr_t)baseModule);
+            spdlog::info("MGS 2: Radar Width: Hook address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)MGS2_RadarWidthAddress - (uintptr_t)baseModule);
 
             static SafetyHookMid MGS2_RadarWidthMidHook{};
             MGS2_RadarWidthMidHook = safetyhook::create_mid(MGS2_RadarWidthScanResult,
@@ -580,7 +580,7 @@ static void Init_HUDFix()
 
             // Radar width offset
             DWORD64 MGS2_RadarWidthOffsetAddress = (uintptr_t)MGS2_RadarWidthScanResult + 0x54;
-            spdlog::info("MGS 2: Radar Width Offset: Hook address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)MGS2_RadarWidthOffsetAddress - (uintptr_t)baseModule);
+            spdlog::info("MGS 2: Radar Width Offset: Hook address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)MGS2_RadarWidthOffsetAddress - (uintptr_t)baseModule);
 
             static SafetyHookMid MGS2_RadarWidthOffsetMidHook{};
             MGS2_RadarWidthOffsetMidHook = safetyhook::create_mid(MGS2_RadarWidthOffsetAddress,
@@ -591,7 +591,7 @@ static void Init_HUDFix()
 
             // Radar height offset
             DWORD64 MGS2_RadarHeightOffsetAddress = (uintptr_t)MGS2_RadarWidthScanResult + 0x90;
-            spdlog::info("MGS 2: Radar Height Offset: Hook address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)MGS2_RadarHeightOffsetAddress - (uintptr_t)baseModule);
+            spdlog::info("MGS 2: Radar Height Offset: Hook address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)MGS2_RadarHeightOffsetAddress - (uintptr_t)baseModule);
 
             static SafetyHookMid MGS2_RadarHeightOffsetMidHook{};
             MGS2_RadarHeightOffsetMidHook = safetyhook::create_mid(MGS2_RadarHeightOffsetAddress,
@@ -610,7 +610,7 @@ static void Init_HUDFix()
         uint8_t* MGS2_CodecPortraitsScanResult = Memory::PatternScanSilent(baseModule, "F3 0F ?? ?? ?? F3 0F ?? ?? F3 0F ?? ?? ?? F3 0F ?? ?? 66 0F ?? ?? 0F ?? ??");
         if (MGS2_CodecPortraitsScanResult)
         {
-            spdlog::info("MGS 2: Codec Portraits: Hook address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)MGS2_CodecPortraitsScanResult - (uintptr_t)baseModule);
+            spdlog::info("MGS 2: Codec Portraits: Hook address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)MGS2_CodecPortraitsScanResult - (uintptr_t)baseModule);
 
             static SafetyHookMid MGS2_CodecPortraitsMidHook{};
             MGS2_CodecPortraitsMidHook = safetyhook::create_mid(MGS2_CodecPortraitsScanResult,
@@ -636,7 +636,7 @@ static void Init_HUDFix()
         uint8_t* MGS2_MotionBlurScanResult = Memory::PatternScanSilent(baseModule, "F3 48 ?? ?? ?? ?? 48 ?? ?? ?? 48 ?? ?? ?? F3 0F ?? ?? ?? ?? ?? ?? 0F ?? ??");
         if (MGS2_MotionBlurScanResult)
         {
-            spdlog::info("MGS 2: Motion Blur: Address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)MGS2_MotionBlurScanResult - (uintptr_t)baseModule);
+            spdlog::info("MGS 2: Motion Blur: Address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)MGS2_MotionBlurScanResult - (uintptr_t)baseModule);
 
             Memory::PatchBytes((uintptr_t)MGS2_MotionBlurScanResult, "\x48\x31\xDB\x90\x90\x90", 6);
             spdlog::info("MGS 2: Motion Blur: Patched instruction.");
@@ -668,7 +668,7 @@ static void Init_HUDFix()
                     }
                 });
 
-            spdlog::info("MG1/2 | MGS 3: HUD Width: Hook address is{:s}+{:x}", sExeName.c_str(), (uintptr_t)MGS3_HUDWidthScanResult - (uintptr_t)baseModule);
+            spdlog::info("MG1/2 | MGS 3: HUD Width: Hook address is{:s}+{:X}", sExeName.c_str(), (uintptr_t)MGS3_HUDWidthScanResult - (uintptr_t)baseModule);
         }
         else if (!MGS3_HUDWidthScanResult)
         {
@@ -683,7 +683,7 @@ static void Init_HUDFix()
         if (MGS2_MGS3_LetterboxingScanResult)
         {
             DWORD64 MGS2_MGS3_LetterboxingAddress = (uintptr_t)MGS2_MGS3_LetterboxingScanResult + 0x6;
-            spdlog::info("MGS 2 | MGS 3: Letterboxing: Address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)MGS2_MGS3_LetterboxingAddress - (uintptr_t)baseModule);
+            spdlog::info("MGS 2 | MGS 3: Letterboxing: Address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)MGS2_MGS3_LetterboxingAddress - (uintptr_t)baseModule);
 
             Memory::Write(MGS2_MGS3_LetterboxingAddress, (int)0);
             spdlog::info("MGS 2 | MGS 3: Letterboxing: Disabled letterboxing.");
@@ -741,7 +741,7 @@ static void Init_Miscellaneous()
         uint8_t* MGS3_MouseSensitivityScanResult = Memory::PatternScanSilent(baseModule, "F3 0F ?? ?? ?? F3 0F ?? ?? 66 0F ?? ?? ?? 0F ?? ?? 66 0F ?? ?? 8B ?? ??");
         if (MGS3_MouseSensitivityScanResult)
         {
-            spdlog::info("MGS 3: Mouse Sensitivity: Address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)MGS3_MouseSensitivityScanResult - (uintptr_t)baseModule);
+            spdlog::info("MGS 3: Mouse Sensitivity: Address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)MGS3_MouseSensitivityScanResult - (uintptr_t)baseModule);
 
             static SafetyHookMid MouseSensitivityXMidHook{};
             MouseSensitivityXMidHook = safetyhook::create_mid(MGS3_MouseSensitivityScanResult,

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -1196,6 +1196,8 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
 {
     if (ul_reason_for_call == DLL_PROCESS_ATTACH)
     {
+        DisableThreadLibraryCalls(hModule);
+
         HMODULE vcruntime140 = GetModuleHandleA("VCRUNTIME140.dll");
         if (vcruntime140)
         {

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -1,8 +1,7 @@
 #include "common.hpp"
-#include "version.h"
 #include "logging.hpp"
 #include "submodule_initiailization.hpp"
-#include <inipp/inipp.h>
+#include "config.hpp"
 
 ///Resources
 #include "d3d11_api.hpp"
@@ -40,69 +39,8 @@
 #include "wireframe.hpp"
 
 
-HMODULE baseModule = GetModuleHandle(NULL);
-HMODULE engineModule;
-HMODULE unityPlayer;
-
-// Version
-std::string const sFixVersion = VERSION_STRING;
-std::string sFixName = FIX_NAME;
-constexpr int iConfigVersion = 4; //increment this when making config changes, along with the number at the bottom of the config file
-                        //that way we can sanity check to ensure people don't have broken/disabled features due to old config files.
-
-
-// Logger
-std::filesystem::path sFixPath;
-std::filesystem::path sExePath;
-std::filesystem::path sGameSavePath;
-std::string sExeName;
-std::string sGameVersion;
-
-// Ini
-inipp::Ini<char> ini;
-std::filesystem::path sConfigFile = sFixName + ".ini";
-std::pair DesktopDimensions = { 0,0 };
-
-// Ini Variables
-bool bVerboseLogging = true;
-bool bAspectFix;
-bool bHUDFix;
-bool bFOVFix;
-bool bOutputResolution;
-int iOutputResX;
-int iOutputResY;
-int iInternalResX;
-int iInternalResY;
-bool bWindowedMode;
-bool bBorderlessMode;
-bool bFramebufferFix;
-bool bLauncherJumpStart;
-int iAnisotropicFiltering;
-bool bDisableTextureFiltering;
-static bool bMouseSensitivity;
-static float fMouseSensitivityXMulti;
-static float fMouseSensitivityYMulti;
-static bool bDisableCursor;
-bool bOutdatedReshade;
-
-bool bShouldCheckForUpdates;
-bool bConsoleNotifications;
-
-// Add this global variable
-bool bIsPS2controltype = false;
-
-// Launcher ini variables
-bool bLauncherConfigSkipLauncher = false;
-int iLauncherConfigCtrlType = 5;
-int iLauncherConfigRegion = 0;
-int iLauncherConfigLanguage = 0;
-std::string sLauncherConfigMSXGame = "mg1";
-int iLauncherConfigMSXWallType = 0;
-std::string sLauncherConfigMSXWallAlign = "C";
-
 // Aspect ratio + HUD stuff
 constexpr float fNativeAspect = 16.0f / 9.0f;
-float fAspectRatio;
 float fAspectMultiplier;
 float fHUDWidth;
 float fHUDHeight;
@@ -113,50 +51,11 @@ float fHUDHeightOffset;
 float fMGS2_EffectScaleX;
 float fMGS2_EffectScaleY;
 
-const std::initializer_list<std::string> kLauncherConfigCtrlTypes = {
-    "ps5",
-    "ps4",
-    "xbox",
-    "nx",
-    "stmd",
-    "kbd",
-    "ps2"
-};
-
-const std::initializer_list<std::string> kLauncherConfigLanguages = {
-    "en",
-    "jp",
-    "fr",
-    "gr",
-    "it",
-    "pr",
-    "sp",
-    "du",
-    "ru"
-};
-
-const std::initializer_list<std::string> kLauncherConfigRegions = {
-    "us",
-    "jp",
-    "eu"
-};
-
-
-const std::map<MgsGame, GameInfo> kGames = {
-    {MGS2, {"Metal Gear Solid 2 MC", "METAL GEAR SOLID2.exe", 2131640}},
-    {MGS3, {"Metal Gear Solid 3 MC", "METAL GEAR SOLID3.exe", 2131650}},
-    {MG, {"Metal Gear / Metal Gear 2 (MSX)", "METAL GEAR.exe", 2131680}},
-};
-
-const GameInfo* game = nullptr;
-MgsGame eGameType =  UNKNOWN;
-const LPCSTR sClassName = "CSD3DWND";
-
-
 // CreateWindowExA Hook
 SafetyHookInline CreateWindowExA_hook{};
 HWND WINAPI CreateWindowExA_hooked(DWORD dwExStyle, LPCSTR lpClassName, LPCSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam)
 {
+    const LPCSTR sClassName = "CSD3DWND";
     if (std::string(lpClassName) == std::string(sClassName))
     {
         if (bBorderlessMode && !(eGameType & UNKNOWN))
@@ -211,233 +110,6 @@ static void Init_CalculateScreenSize()
     spdlog::info("Current Resolution: Correct HUD Height: {}", fHUDHeight);
     spdlog::info("Current Resolution: HUD Width Offset: {}", fHUDWidthOffset);
     spdlog::info("Current Resolution: HUD Height Offset: {}", fHUDHeightOffset);
-}
-
-
-static void Init_ReadConfig()
-{
-    // Initialise config
-    std::ifstream iniFile((sExePath / sFixPath / sConfigFile).string());
-    if (!iniFile) 
-    {
-        spdlog::error("CONFIG ERROR: File not found: {}", (sExePath / sFixPath / sConfigFile).string());
-        Logging::ShowConsole();
-        std::cout << "" << sFixName << " v" << sFixVersion << " loaded." << std::endl;
-        std::cout << "ERROR: Could not locate config file." << std::endl;
-        std::cout << "ERROR: Make sure " << sConfigFile << " is located in " << sExePath / sFixPath << std::endl;
-        return FreeLibraryAndExitThread(baseModule, 1);
-    }
-
-    spdlog::info("Config file: {}", (sExePath / sFixPath / sConfigFile).string());
-    ini.parse(iniFile);
-    if (!ini.errors.empty())
-    {
-        spdlog::error("Error parsing ini file, encountered {} errors at these lines:", ini.errors.size());
-        Logging::ShowConsole();
-        std::cout << "Error parsing ini file, encountered " << ini.errors.size() << " errors at these lines:" << std::endl;
-        for (auto err : ini.errors)
-        {
-            spdlog::error(err);
-            std::cout << err << std::endl;
-        }
-    }
-
-    int loadedConfigVersion;
-    inipp::get_value(ini.sections["Config Version"], "Version", loadedConfigVersion);
-    if (loadedConfigVersion != iConfigVersion) 
-    {
-        spdlog::error("CONFIG ERROR: Config file version mismatch! Expected version {}, but found version {}.", iConfigVersion, loadedConfigVersion);
-        Logging::ShowConsole();
-        std::cout << "" << sFixName << " v" << sFixVersion << " loaded." << std::endl;
-        std::cout << "MGSHDFix CONFIG ERROR: Outdated config file!" << std::endl;
-        std::cout << "MGSHDFix CONFIG ERROR: Please install -all- the files from the latest release!" << std::endl;
-        return FreeLibraryAndExitThread(baseModule, 1);
-    }
-
-    // Grab desktop resolution
-    DesktopDimensions = Util::GetPhysicalDesktopDimensions();
-
-    // Read ini file
-    bVerboseLogging = Util::stringToBool(ini.sections["Verbose Logging"]["Enabled"]);
-    bOutputResolution = Util::stringToBool(ini.sections["Output Resolution"]["Enabled"]);
-    inipp::get_value(ini.sections["Output Resolution"], "Width", iOutputResX);
-    inipp::get_value(ini.sections["Output Resolution"], "Height", iOutputResY);
-    bWindowedMode = Util::stringToBool(ini.sections["Output Resolution"]["Windowed"]);
-    bBorderlessMode = Util::stringToBool(ini.sections["Output Resolution"]["Borderless"]);
-    inipp::get_value(ini.sections["Internal Resolution"], "Width", iInternalResX);
-    inipp::get_value(ini.sections["Internal Resolution"], "Height", iInternalResY);
-    inipp::get_value(ini.sections["Anisotropic Filtering"], "Samples", iAnisotropicFiltering);
-    bDisableTextureFiltering = Util::stringToBool(ini.sections["Disable Texture Filtering"]["DisableTextureFiltering"]);
-    bFramebufferFix = Util::stringToBool(ini.sections["Framebuffer Fix"]["Enabled"]);
-    bLauncherJumpStart = Util::stringToBool(ini.sections["Launcher Config"]["LauncherJumpStart"]);
-    g_IntroSkip.isEnabled = Util::stringToBool(ini.sections["Skip Intro Logos"]["Enabled"]);
-    g_StereoAudioFix.isEnabled = Util::stringToBool(ini.sections["Force Stereo Audio"]["Enabled"]);
-    g_PauseOnFocusLoss.bPauseOnFocusLoss = Util::stringToBool(ini.sections["Pause On Focus Loss"]["Enabled"]);
-    g_PauseOnFocusLoss.bSpeedrunnerBugfixOverride = Util::stringToBool(ini.sections["Pause On Focus Loss"]["SpeedrunnerBugfixOverride"]);
-    g_MuteWarning.bEnabled = Util::stringToBool(ini.sections["Mute Warning"]["Enabled"]);
-
-    bShouldCheckForUpdates = Util::stringToBool(ini.sections["Update Notifications"]["CheckForUpdates"]);
-    bConsoleNotifications = Util::stringToBool(ini.sections["Update Notifications"]["ConsoleNotifications"]);
-    g_StatPersistence.bAchievementPersistenceEnabled = Util::stringToBool(ini.sections["Achievement Persistence"]["Enabled"]);
-    g_SteamAPI.bResetAchievements = Util::stringToBool(ini.sections["Reset All Achievements"]["Reset_All_Achievements"]);
-
-    /*//INITIALIZE(Init_GammaShader());
-    //INITIALIZE(g_DistanceCulling.Initialize());
-    //INITIALIZE(g_MultiSampleAntiAliasing.Initialize());
-    //INITIALIZE(g_Wireframe.Initialize());
-
-    //INITIALIZE(g_AimAfterEquipFix.Initialize());
-    //INITIALIZE(g_ColorFilterFix.Initialize());*/
-
-    //inipp::get_value(ini.sections["MG1 Custom Loading Screens"], "Enabled", g_MG1CustomLoadingScreens.isEnabled);
-    bMouseSensitivity = Util::stringToBool(ini.sections["Mouse Sensitivity"]["Enabled"]);
-    inipp::get_value(ini.sections["Mouse Sensitivity"], "X Multiplier", fMouseSensitivityXMulti);
-    inipp::get_value(ini.sections["Mouse Sensitivity"], "Y Multiplier", fMouseSensitivityYMulti);
-    bDisableCursor = Util::stringToBool(ini.sections["Disable Mouse Cursor"]["Enabled"]);
-    inipp::get_value(ini.sections["Texture Buffer"], "SizeMB", g_TextureBufferSize.iTextureBufferSizeMB);
-    bAspectFix = Util::stringToBool(ini.sections["Fix Aspect Ratio"]["Enabled"]);
-    bHUDFix = Util::stringToBool(ini.sections["Fix HUD"]["Enabled"]);
-    bFOVFix = Util::stringToBool(ini.sections["Fix FOV"]["Enabled"]);
-    bLauncherConfigSkipLauncher = Util::stringToBool(ini.sections["Launcher Config"]["SkipLauncher"]);
-
-    // Read launcher settings from ini
-    std::string sLauncherConfigCtrlType = "kbd";
-    std::string sLauncherConfigRegion = "us";
-    std::string sLauncherConfigLanguage = "en";
-    inipp::get_value(ini.sections["Launcher Config"], "CtrlType", sLauncherConfigCtrlType);
-    inipp::get_value(ini.sections["Launcher Config"], "Region", sLauncherConfigRegion);
-    inipp::get_value(ini.sections["Launcher Config"], "Language", sLauncherConfigLanguage);
-    inipp::get_value(ini.sections["Launcher Config"], "MSXGame", sLauncherConfigMSXGame);
-    inipp::get_value(ini.sections["Launcher Config"], "MSXWallType", iLauncherConfigMSXWallType);
-    inipp::get_value(ini.sections["Launcher Config"], "MSXWallAlign", sLauncherConfigMSXWallAlign);
-    iLauncherConfigCtrlType = Util::findStringInVector(sLauncherConfigCtrlType, kLauncherConfigCtrlTypes);
-    iLauncherConfigRegion = Util::findStringInVector(sLauncherConfigRegion, kLauncherConfigRegions);
-    iLauncherConfigLanguage = Util::findStringInVector(sLauncherConfigLanguage, kLauncherConfigLanguages);
-    
-
-
-    // Log config parse
-    spdlog::info("Config Parse: Verbose Logging: {}", bVerboseLogging);
-    spdlog::info("Config Parse: Custom Output Resolution: {}", bOutputResolution);
-    if (iOutputResX == 0 || iOutputResY == 0) 
-    {
-        iOutputResX = DesktopDimensions.first;
-        iOutputResY = DesktopDimensions.second;
-    }
-    spdlog::info("Config Parse: Output Resolution (X): {}", iOutputResX);
-    spdlog::info("Config Parse: Output Resolution (Y): {}", iOutputResY);
-    if (iInternalResX == 0 || iInternalResY == 0) 
-    {
-        iInternalResX = iOutputResX;
-        iInternalResY = iOutputResY;
-    }
-    spdlog::info("Config Parse: Internal Resolution (X): {}", iInternalResX);
-    spdlog::info("Config Parse: Internal Resolution (Y): {}", iInternalResY);
-    spdlog::info("Config Parse: Windowed Mode: {}", bWindowedMode);
-    spdlog::info("Config Parse: Borderless Mode: {}", bBorderlessMode);
-    spdlog::info("Config Parse: Fix Ultrawide Framebuffer: {}", bFramebufferFix);
-    spdlog::info("Config Parse: Fix Ultrawide Aspect Ratio: {}", bAspectFix);
-    spdlog::info("Config Parse: Fix Ultrawide HUD: {}", bHUDFix);
-    spdlog::info("Config Parse: Fix Ultrawide FOV: {}", bFOVFix);
-    spdlog::info("Config Parse: Texture Buffer Size (PER TEXTURE): {}MB", g_TextureBufferSize.iTextureBufferSizeMB); //g_TextureBufferSize
-    spdlog::info("Config Parse: Anisotropic Filtering Level: {}", iAnisotropicFiltering);
-    if (iAnisotropicFiltering < 0 || iAnisotropicFiltering > 16)
-    {
-        iAnisotropicFiltering = std::clamp(iAnisotropicFiltering, 0, 16);
-        spdlog::info("Config Parse: Anisotropic Filtering value invalid, clamped to {}", iAnisotropicFiltering);
-    }
-    spdlog::info("Config Parse: Disable Texture Filtering: {}", bDisableTextureFiltering);
-    spdlog::info("Config Parse: Disable Cursor Icon: {}", bDisableCursor);
-    spdlog::info("Config Parse: Mouse Sensitivity: {}", bMouseSensitivity);
-    spdlog::info("Config Parse: Mouse Sensitivity X Multiplier: {}", fMouseSensitivityXMulti);
-    spdlog::info("Config Parse: Mouse Sensitivity Y Multiplier: {}", fMouseSensitivityYMulti);
-
-
-    //spdlog::info("Config Parse: bMG1CustomLoadingScreens: {}", g_MG1CustomLoadingScreens.isEnabled);
-
-    spdlog::info("Config Parse: Launcher Jump Start: {}", bLauncherJumpStart);
-
-    spdlog::info("Config Parse: Launcher - Skip Launcher: {}", bLauncherConfigSkipLauncher);
-    spdlog::info("Config Parse: Launcher - Controller Glyphs: {} ( {} )", iLauncherConfigCtrlType, Util::GetUppercaseNameAtIndex(kLauncherConfigCtrlTypes, iLauncherConfigCtrlType));
-    spdlog::info("Config Parse: Launcher - MSX Game: {}", sLauncherConfigMSXGame);
-    spdlog::info("Config Parse: Launcher - Region: {} ({})", iLauncherConfigRegion, Util::GetUppercaseNameAtIndex(kLauncherConfigRegions, iLauncherConfigRegion));
-    spdlog::info("Config Parse: Launcher - Language: {} ({})", iLauncherConfigLanguage, Util::GetUppercaseNameAtIndex(kLauncherConfigLanguages, iLauncherConfigLanguage));
-    if (std::string ps2Str = "ps2"; (iLauncherConfigCtrlType == Util::findStringInVector(ps2Str, kLauncherConfigCtrlTypes)))
-    {
-        bIsPS2controltype = true;
-        ps2Str = "ps4";
-        iLauncherConfigCtrlType = Util::findStringInVector(ps2Str, kLauncherConfigCtrlTypes);
-    }
-    spdlog::info("Config Parse: Skip Intro Videos: {}", g_IntroSkip.isEnabled);
-    spdlog::info("Config Parse: Pause On Focus Loss: {}", g_PauseOnFocusLoss.bPauseOnFocusLoss);
-    spdlog::info("Config Parse: Cutscene Asset Loading Fix - Speedrunner Override: {}", g_PauseOnFocusLoss.bSpeedrunnerBugfixOverride);
-
-    spdlog::info("Config Parse: Force Stereo Audio: {}", g_StereoAudioFix.isEnabled);
-    spdlog::info("Config Parse: Muted Audio Console Warnings: {}", g_MuteWarning.bEnabled);
-    if (eGameType & (MGS2 | MGS3))
-    {
-        g_VectorScalingFix.bEnableVectorLineFix = Util::stringToBool(ini.sections["Vector Line Fix"]["Enabled"]);
-        spdlog::info("Config Parse: Fix Vector Effect (Rain) Scaling: {}", g_VectorScalingFix.bEnableVectorLineFix);
-        if (g_VectorScalingFix.bEnableVectorLineFix)
-        {
-            inipp::get_value(ini.sections["Vector Line Fix"], "Line Scale", g_VectorScalingFix.iVectorLineScale);
-            spdlog::info("Config Parse: Vector Effect Width: {} / {} pixels wide.", g_VectorScalingFix.iVectorLineScale, iInternalResY / g_VectorScalingFix.iVectorLineScale);
-        }
-    }
-
-    spdlog::info("Cofig Parse: Check for mod updates: {}", bShouldCheckForUpdates);
-    if (bShouldCheckForUpdates)
-    {
-        spdlog::info("Cofig Parse: Mod update console notifications: {}", bConsoleNotifications);
-    }
-
-    spdlog::info("Config Parse: Achievement Persistence: {}", g_StatPersistence.bAchievementPersistenceEnabled);
-    spdlog::info("Config Parse: Reset Achievements: {}", g_SteamAPI.bResetAchievements);
-}
-
-static bool DetectGame()
-{
-    eGameType = UNKNOWN;
-    // Special handling for launcher.exe
-    if (sExeName == "launcher.exe")
-    {
-        for (const auto& [type, info] : kGames)
-        {
-            auto gamePath = sExePath.parent_path() / info.ExeName;
-            if (std::filesystem::exists(gamePath))
-            {
-                spdlog::info("Detected launcher for game: {} (app {})", info.GameTitle.c_str(), info.SteamAppId);
-                eGameType = LAUNCHER;
-                unityPlayer = GetModuleHandleA("UnityPlayer.dll");
-                game = &info;
-                return true;
-            }
-        }
-
-        spdlog::error("Failed to detect supported game, unknown launcher");
-        FreeLibraryAndExitThread(baseModule, 1);
-    }
-
-    for (const auto& [type, info] : kGames)
-    {
-        if (info.ExeName == sExeName)
-        {
-            spdlog::info("Detected game: {} (app {})", info.GameTitle.c_str(), info.SteamAppId);
-            eGameType = type;
-            game = &info;
-
-            sGameSavePath = sExePath / (eGameType & MG ? "mg12_savedata_win" : eGameType & MGS2 ? "mgs2_savedata_win" : "mgs3_savedata_win");
-            spdlog::info("Game Save Path: {}", sGameSavePath.string());
-            if (engineModule = GetModuleHandleA("Engine.dll"); !engineModule)
-            {
-                spdlog::error("Failed to get Engine.dll module handle");
-            }
-            return true;
-        }
-    }
-
-    spdlog::error("Failed to detect supported game, {} isn't supported by MGSHDFix", sExeName.c_str());
-    FreeLibraryAndExitThread(baseModule, 1);
 }
 
 static void Init_FixDPIScaling()
@@ -1342,11 +1014,55 @@ static void Init_LauncherConfigOverride()
 }
 
 
-void afterSteamInit()
+static bool DetectGame()
 {
-    
+    eGameType = UNKNOWN;
+    // Special handling for launcher.exe
+    if (sExeName == "launcher.exe")
+    {
+        for (const auto& [type, info] : kGames)
+        {
+            auto gamePath = sExePath.parent_path() / info.ExeName;
+            if (std::filesystem::exists(gamePath))
+            {
+                spdlog::info("Detected launcher for game: {} (app {})", info.GameTitle.c_str(), info.SteamAppId);
+                eGameType = LAUNCHER;
+                unityPlayer = GetModuleHandleA("UnityPlayer.dll");
+                game = &info;
+                return true;
+            }
+        }
+
+        spdlog::error("Failed to detect supported game, unknown launcher");
+        FreeLibraryAndExitThread(baseModule, 1);
+    }
+
+    for (const auto& [type, info] : kGames)
+    {
+        if (info.ExeName == sExeName)
+        {
+            spdlog::info("Detected game: {} (app {})", info.GameTitle.c_str(), info.SteamAppId);
+            eGameType = type;
+            game = &info;
+
+            sGameSavePath = sExePath / (eGameType & MG ? "mg12_savedata_win" : eGameType & MGS2 ? "mgs2_savedata_win" : "mgs3_savedata_win");
+            spdlog::info("Game Save Path: {}", sGameSavePath.string());
+            if (engineModule = GetModuleHandleA("Engine.dll"); !engineModule)
+            {
+                spdlog::error("Failed to get Engine.dll module handle");
+            }
+            return true;
+        }
+    }
+
+    spdlog::error("Failed to detect supported game, {} isn't supported by MGSHDFix", sExeName.c_str());
+    FreeLibraryAndExitThread(baseModule, 1);
 }
 
+void AfterSteamInitialized()
+{
+    g_StatPersistence.OnSteamInitialized();
+}
 
 void preCreateDXGIFactory()
 {
@@ -1376,25 +1092,13 @@ void afterD3D11CreateDevice()
     //SetGamma(1.0);
 }
 
-static void CheckForUpdates()
-{
-    if (!bShouldCheckForUpdates)
-    {
-        spdlog::info("Mod update checking disabled via config.");
-        return;
-    }
-    std::filesystem::path cacheFilePath = sGameSavePath / (sFixName + "_version_check.txt");
-    LatestVersionChecker checker(cacheFilePath);
-    checker.checkForUpdates();
-}
-
 static void InitializeSubsystems()
 {
     //Initialization order (these systems initialize vars used by following ones.)
     INITIALIZE(g_Logging.LogSysInfo());            //0
     INITIALIZE(DetectGame());                      //1
     INITIALIZE(ASILoaderCompatibility::Check());   //2
-    INITIALIZE(Init_ReadConfig());                 //3
+    INITIALIZE(Config::Read());                    //3
     INITIALIZE(g_GameVars.Initialize());           //4
     INITIALIZE(g_D3D11Hooks.Initialize());         //5 Caches the D3DDevice, DXGIFactory, and D3DContext from D3DCreateDevice/DXGICreateFactory
     INITIALIZE(ReshadeCompatibility::Check());     //6 Dependent on ReadConfig, must also be before LauncherConfigOverride to warn the user before a crash.

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -1384,7 +1384,7 @@ static void CheckForUpdates()
         return;
     }
     std::filesystem::path cacheFilePath = sGameSavePath / (sFixName + "_version_check.txt");
-    LatestVersionChecker checker(sFixVersion, REPO_OWNER, REPO_NAME, cacheFilePath);
+    LatestVersionChecker checker(cacheFilePath);
     checker.checkForUpdates();
 }
 

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -230,7 +230,17 @@ static void Init_ReadConfig()
 
     spdlog::info("Config file: {}", (sExePath / sFixPath / sConfigFile).string());
     ini.parse(iniFile);
-    
+    if (!ini.errors.empty())
+    {
+        spdlog::error("Error parsing ini file, encountered {} errors at these lines:", ini.errors.size());
+        Logging::ShowConsole();
+        std::cout << "Error parsing ini file, encountered " << ini.errors.size() << " errors at these lines:" << std::endl;
+        for (auto err : ini.errors)
+        {
+            spdlog::error(err);
+            std::cout << err << std::endl;
+        }
+    }
 
     int loadedConfigVersion;
     inipp::get_value(ini.sections["Config Version"], "Version", loadedConfigVersion);

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -1358,6 +1358,8 @@ void afterD3D11CreateDevice()
 {
     g_VectorScalingFix.LoadCompiledShader();
     g_MuteWarning.CheckStatus();
+    g_SteamAPI.LogControllers();
+
 
     //createGammaShader();
 

--- a/src/features/mg1_custom_loading_screens.cpp
+++ b/src/features/mg1_custom_loading_screens.cpp
@@ -1,5 +1,7 @@
 #include "common.hpp"
 #include "mg1_custom_loading_screens.hpp"
+
+#include "config.hpp"
 #include "logging.hpp"
 
 void MG1CustomLoadingScreens::Initialize() const

--- a/src/features/stat_persistence.cpp
+++ b/src/features/stat_persistence.cpp
@@ -190,7 +190,6 @@ void StatPersistence::MGS3_SnakeEyes_SetSeen(int iSceneNumber)
             g_StatPersistence.bUpdatedState = true; \
             return; \
         } \
-        spdlog::info("setting {} to cached val {}", iCurrentNum, g_StatPersistence.currentCountVar+1);\
         reghelpers::set_eax(ctx, g_StatPersistence.currentCountVar++); \
     } while (0)
 

--- a/src/features/texture_buffer_size.cpp
+++ b/src/features/texture_buffer_size.cpp
@@ -16,9 +16,9 @@ void TextureBufferSize::Initialize() const
             if (uint8_t* MGS3_CTextureBufferMallocResult = Memory::PatternScanSilent(baseModule, "75 ?? B9 00 00 00 08 FF"))
             {
                 uint32_t* bufferAmount = (uint32_t*)(MGS3_CTextureBufferMallocResult + 3);
-                spdlog::info("MG/MG2 | MGS 3: Texture Buffer Size: #{} ({:s}+{:x}) old buffer size: {}", i, sExeName.c_str(), reinterpret_cast<uintptr_t>(MGS3_CTextureBufferMallocResult) - reinterpret_cast<uintptr_t>(baseModule), static_cast<uintptr_t>(*bufferAmount));
+                spdlog::info("MG/MG2 | MGS 3: Texture Buffer Size: #{} ({:s}+{:X}) old buffer size: {}", i, sExeName.c_str(), reinterpret_cast<uintptr_t>(MGS3_CTextureBufferMallocResult) - reinterpret_cast<uintptr_t>(baseModule), static_cast<uintptr_t>(*bufferAmount));
                 Memory::Write((uintptr_t)bufferAmount, NewSize);
-                spdlog::info("MG/MG2 | MGS 3: Texture Buffer Size: #{} ({:s}+{:x}) new buffer size: {}", i, sExeName.c_str(), reinterpret_cast<uintptr_t>(MGS3_CTextureBufferMallocResult) - reinterpret_cast<uintptr_t>(baseModule), static_cast<uintptr_t>(*bufferAmount));
+                spdlog::info("MG/MG2 | MGS 3: Texture Buffer Size: #{} ({:s}+{:X}) new buffer size: {}", i, sExeName.c_str(), reinterpret_cast<uintptr_t>(MGS3_CTextureBufferMallocResult) - reinterpret_cast<uintptr_t>(baseModule), static_cast<uintptr_t>(*bufferAmount));
             }
             else
             {
@@ -36,9 +36,9 @@ void TextureBufferSize::Initialize() const
             if (uint8_t* MGS3_CBaseTextureMallocScanResult = Memory::PatternScanSilent(baseModule, "75 ?? 00 00 00 08 8B ??"))
             {
                 uint32_t* bufferAmount = reinterpret_cast<uint32_t*>(MGS3_CBaseTextureMallocScanResult + 3);
-                spdlog::info("MG/MG2 | MGS 3: Texture Buffer Size: #{} ({:s}+{:x}) old buffer size: {}", 9, sExeName.c_str(), reinterpret_cast<uintptr_t>(MGS3_CBaseTextureMallocScanResult) - reinterpret_cast<uintptr_t>(baseModule), static_cast<uintptr_t>(*bufferAmount));
+                spdlog::info("MG/MG2 | MGS 3: Texture Buffer Size: #{} ({:s}+{:X}) old buffer size: {}", 9, sExeName.c_str(), reinterpret_cast<uintptr_t>(MGS3_CBaseTextureMallocScanResult) - reinterpret_cast<uintptr_t>(baseModule), static_cast<uintptr_t>(*bufferAmount));
                 Memory::Write(reinterpret_cast<uintptr_t>(bufferAmount), NewSize);
-                spdlog::info("MG/MG2 | MGS 3: Texture Buffer Size: #{} ({:s}+{:x}) new buffer size: {}", 9, sExeName.c_str(), reinterpret_cast<uintptr_t>(MGS3_CBaseTextureMallocScanResult) - reinterpret_cast<uintptr_t>(baseModule), static_cast<uintptr_t>(*bufferAmount));
+                spdlog::info("MG/MG2 | MGS 3: Texture Buffer Size: #{} ({:s}+{:X}) new buffer size: {}", 9, sExeName.c_str(), reinterpret_cast<uintptr_t>(MGS3_CBaseTextureMallocScanResult) - reinterpret_cast<uintptr_t>(baseModule), static_cast<uintptr_t>(*bufferAmount));
             }
             else
             {

--- a/src/fixes/color_filters.cpp
+++ b/src/fixes/color_filters.cpp
@@ -36,7 +36,7 @@ void ColorFilterFix::Initialize()
         // Patch the color filter to use normal filter (0x38) instead of green (0x39) or blue (0x3A)
         Memory::PatchBytes(MGS2_ColorFilterAddress, "\x38", 1);
         
-        spdlog::info("MGS 2: Color Filter Fix: Patched color filter to normal at address {:s}+{:x}", 
+        spdlog::info("MGS 2: Color Filter Fix: Patched color filter to normal at address {:s}+{:X}", 
                      sExeName.c_str(), (uintptr_t)MGS2_ColorFilterResult - (uintptr_t)baseModule);
     }
     */

--- a/src/fixes/effect_speeds.cpp
+++ b/src/fixes/effect_speeds.cpp
@@ -30,8 +30,11 @@ constexpr double FRAME_IOP_MULTIPLIER = (60 / PS2_IOP_CLOCKSPEED);
 SafetyHookInline solidusFireDashAct_hook {};
 int64_t __fastcall MGS2_solidusFireDashAct(int64_t work)
 {
-    if (!g_GameVars.InCutscene()) // only slow down during cutscenes. the boss fight (which includes pad demos) runs properly at normal game speed.
+    if (!g_GameVars.InCutscene()) // only slow down during cutscenes. the boss fight (which includes pad demos/scripted sequences) runs properly at normal game speed.
+    { 
         return solidusFireDashAct_hook.fastcall<int64_t>(work);
+    }
+
 
     std::chrono::time_point<std::chrono::high_resolution_clock> current_time = std::chrono::high_resolution_clock::now();
     if (current_time >= g_EffectSpeedFix.solidusDashAct_NextUpdate)

--- a/src/fixes/line_scaling.cpp
+++ b/src/fixes/line_scaling.cpp
@@ -2,42 +2,76 @@
 #include "line_scaling.hpp"
 #include "d3d11_api.hpp"
 #include <d3dcompiler.h>
-
+#include <wrl/client.h>
 #include "config.hpp"
 #include "logging.hpp"
 
+using Microsoft::WRL::ComPtr;
 
 static SafetyHookInline MGS3_DrawIndexedPrimitive_Hook {};
+
 uint64_t MGS3_DrawIndexedPrimitive_Hooked(void* CD3DCachedDevice, int topologyType, int BaseVertexIndex, int MinVertexIndex, int NumVertices, int startIndex, int primCount)
-{ //This is called every frame, DO NOT add logging or the I/O will nuke performance.
-    if(!(topologyType == 0x1 || topologyType == 0x2))
+{
+    if (!(topologyType == 0x1 || topologyType == 0x2))
     {
         return MGS3_DrawIndexedPrimitive_Hook.call<uint64_t>(CD3DCachedDevice, topologyType, BaseVertexIndex, MinVertexIndex, NumVertices, startIndex, primCount);
     }
-    g_D3D11Hooks.d3dDeviceContext->GSSetShader(g_D3D11Hooks.geometryShader, nullptr, 0);
+
+    if (!g_D3D11Hooks.d3dDeviceContext)
+    {
+        spdlog::error("MGS 2 | MGS 3: Vector Line Fix - d3dDeviceContext is null during draw hook");
+        return MGS3_DrawIndexedPrimitive_Hook.call<uint64_t>(CD3DCachedDevice, topologyType, BaseVertexIndex, MinVertexIndex, NumVertices, startIndex, primCount);
+    }
+
+    if (!g_D3D11Hooks.geometryShader)
+    {
+        spdlog::error("MGS 2 | MGS 3: Vector Line Fix - geometryShader is null during draw hook");
+    }
+    else
+    {
+        g_D3D11Hooks.d3dDeviceContext->GSSetShader(g_D3D11Hooks.geometryShader, nullptr, 0);
+    }
+
     auto ret = MGS3_DrawIndexedPrimitive_Hook.call<uint64_t>(CD3DCachedDevice, topologyType, BaseVertexIndex, MinVertexIndex, NumVertices, startIndex, primCount);
+
     g_D3D11Hooks.d3dDeviceContext->GSSetShader(nullptr, nullptr, 0);
     return ret;
 }
 
 void VectorScalingFix::LoadCompiledShader()
 {
-    if (!g_D3D11Hooks.geometryShader && compiledShaderBytecode && g_D3D11Hooks.d3dDevice)
+    if (!(eGameType & (MGS2|MGS3)))
     {
-        HRESULT result = g_D3D11Hooks.d3dDevice->CreateGeometryShader(
-            compiledShaderBytecode->GetBufferPointer(),
-            compiledShaderBytecode->GetBufferSize(),
-            nullptr,
-            &g_D3D11Hooks.geometryShader
-        );
+        return;
+    }
+    if (!g_D3D11Hooks.d3dDevice)
+    {
+        spdlog::error("MGS 2 | MGS 3: Vector Line Fix - d3ddevice is null");
+        return;
+    }
 
-        if (FAILED(result))
-            spdlog::error("MGS 2 | MGS 3: Vector Line Fix - Load Shader: Failed to create geometry shader on device");
-        else
-            spdlog::info("MGS 2 | MGS 3: Vector Line Fix - Load Shader: Successfully loaded geometry shader.");
+    if (!compiledShaderBytecode || compiledShaderBytecode->GetBufferSize() == 0 || !compiledShaderBytecode->GetBufferPointer())
+    {
+        spdlog::error("MGS 2 | MGS 3: Vector Line Fix - Compiled bytecode is invalid (empty or null buffer)");
+        return;
+    }
+
+    HRESULT hr = g_D3D11Hooks.d3dDevice->CreateGeometryShader(
+        compiledShaderBytecode->GetBufferPointer(),
+        compiledShaderBytecode->GetBufferSize(),
+        nullptr,
+        &g_D3D11Hooks.geometryShader
+    );
+
+    if (FAILED(hr))
+    {
+        spdlog::error("MGS 2 | MGS 3: Vector Line Fix - CreateGeometryShader failed (HRESULT: 0x{:08X})", hr);
+    }
+    else
+    {
+        spdlog::info("MGS 2 | MGS 3: Vector Line Fix - Geometry shader created successfully");
     }
 }
-
 
 bool VectorScalingFix::CompileGeometryShader()
 {
@@ -48,27 +82,27 @@ bool VectorScalingFix::CompileGeometryShader()
         return false;
     }
 
-
     pD3DCompile D3DCompileFunc = reinterpret_cast<pD3DCompile>(GetProcAddress(d3dcompiler, "D3DCompile"));
     if (!D3DCompileFunc)
     {
         spdlog::error("MGS 2 | MGS 3: Vector Line Fix - CompileGeometryShader: Failed to get address for D3DCompile");
+        FreeLibrary(d3dcompiler);
         return false;
     }
 
     if (iVectorLineScale < 1)
     {
-        spdlog::info("MGS 2 | MGS 3: Vector Line Fix - CompileGeometryShader: Invalid line scale! Defaulting to 360");
+        spdlog::info("MGS 2 | MGS 3: Vector Line Fix - CompileGeometryShader: Invalid scale, defaulting to {}", DEFAULT_LINE_SCALE);
         iVectorLineScale = DEFAULT_LINE_SCALE;
     }
-    if(iVectorLineScale < DEFAULT_LINE_SCALE*0.5)
+    if (iVectorLineScale < DEFAULT_LINE_SCALE * 0.5)
     {
         spdlog::warn("Config Warning");
-        spdlog::warn("Line scale is currently set to more that double the default size of Screen Height / 360 (6 pixels wide,) with individual raindrops currently set to {} ({} pixels wide.)", iVectorLineScale, iInternalResY / iVectorLineScale);
+        spdlog::warn("Line scale is currently set to more than double the default size of Screen Height / 360 (6 pixels wide), with individual raindrops currently set to {} ({} pixels wide).", iVectorLineScale, iInternalResY / iVectorLineScale);
         spdlog::warn("If you intend for line effects to be MASSIVE like this, set \"Silence Scaling Warnings\" to true in the config");
         Logging::ShowConsole();
         std::cout << "MGSHDFix Config Warning:\n"
-                     "Line scale is currently set to more that double the default size of Screen Height/360 (" << iInternalResY / 360 << " pixels wide),\n"
+                     "Line scale is currently set to more than double the default size of Screen Height/360 (" << iInternalResY / 360 << " pixels wide),\n"
                      "with individual raindrops currently set to " << iVectorLineScale << " (" << iInternalResY / iVectorLineScale << " pixels wide.)\n"
                      "If you intend for line effects to be MASSIVE like this, set \"Silence Scaling Warnings\" to true in the config";
     }
@@ -76,15 +110,24 @@ bool VectorScalingFix::CompileGeometryShader()
     {
         spdlog::info("MGS 2 | MGS 3: Vector Line Fix - CompileGeometryShader: Line Scale before: {}", iVectorLineScale);
     }
+
     iVectorLineScale = round(iInternalResY / iVectorLineScale);
+    if (iVectorLineScale <= 0)
+    {
+        spdlog::error("MGS 2 | MGS 3: Vector Line Fix - CompileGeometryShader: Computed invalid iVectorLineScale <= 0, clamping to 1");
+        iVectorLineScale = 1;
+    }
+
     spdlog::info("MGS 2 | MGS 3: Vector Line Fix - CompileGeometryShader: Target Pixel Width = : {}", iVectorLineScale);
+
     iVectorLineScale = (iInternalResY / iVectorLineScale);
     spdlog::info("MGS 2 | MGS 3: Vector Line Fix - CompileGeometryShader: Line Scale after rounding: {}", iVectorLineScale);
+
     const std::string shaderString = R"(
         struct VS_OUTPUT {
-            float4 Position : SV_Position; 
-            float4 param1 : TEXCOORD0;     
-            float4 param2 : TEXCOORD1;    
+            float4 Position : SV_Position;
+            float4 param1 : TEXCOORD0;
+            float4 param2 : TEXCOORD1;
         };
         struct GS_OUTPUT {
             float4 Position : SV_Position;
@@ -128,12 +171,13 @@ bool VectorScalingFix::CompileGeometryShader()
             OutputStream.RestartStrip();
         }
     )";
-    const char* shaderCode = shaderString.c_str();
-    ID3DBlob* compiledShader;
-    ID3DBlob* errorMsgs;
+
+    ComPtr<ID3DBlob> compiledShader = nullptr;
+    ComPtr<ID3DBlob> errorMsgs = nullptr;
+
     HRESULT hr = D3DCompileFunc(
-        shaderCode,
-        strlen(shaderCode),
+        shaderString.c_str(),
+        shaderString.size(),
         "geometry_shader",
         nullptr,
         nullptr,
@@ -141,23 +185,24 @@ bool VectorScalingFix::CompileGeometryShader()
         "gs_4_0",
         0,
         0,
-        &compiledShader,
-        &errorMsgs
+        compiledShader.GetAddressOf(),
+        errorMsgs.GetAddressOf()
     );
     if (FAILED(hr))
     {
         if (errorMsgs)
         {
-            spdlog::error("MGS 2 | MGS 3: Vector Line Fix - CompileGeometryShader: Shader compile failed with error: {}",
-                static_cast<const char*>(errorMsgs->GetBufferPointer()));
+            spdlog::error("MGS 2 | MGS 3: Vector Line Fix - CompileGeometryShader: Shader compile failed:\n{}", static_cast<const char*>(errorMsgs->GetBufferPointer()));
         }
         else
         {
             spdlog::error("MGS 2 | MGS 3: Vector Line Fix - CompileGeometryShader: Shader compile failed with HRESULT: 0x{:08X}", hr);
         }
+        FreeLibrary(d3dcompiler);
         return false;
     }
     compiledShaderBytecode = compiledShader;
+    FreeLibrary(d3dcompiler);
     spdlog::info("MGS 2 | MGS 3: Vector Line Fix - CompileGeometryShader: Shader compiled successfully!");
     return true;
 }

--- a/src/fixes/line_scaling.cpp
+++ b/src/fixes/line_scaling.cpp
@@ -2,6 +2,8 @@
 #include "line_scaling.hpp"
 #include "d3d11_api.hpp"
 #include <d3dcompiler.h>
+
+#include "config.hpp"
 #include "logging.hpp"
 
 

--- a/src/fixes/line_scaling.hpp
+++ b/src/fixes/line_scaling.hpp
@@ -1,5 +1,7 @@
 ﻿#pragma once
+
 #include <d3d11.h>
+#include <wrl/client.h>
 
 class VectorScalingFix final
 {
@@ -7,7 +9,8 @@ private:
     bool CompileGeometryShader();
 
     static constexpr int DEFAULT_LINE_SCALE = 360;
-    ID3DBlob* compiledShaderBytecode = nullptr;
+
+    Microsoft::WRL::ComPtr<ID3DBlob> compiledShaderBytecode;
 
 public:
     void Initialize();

--- a/src/fixes/pause_on_focus_loss.cpp
+++ b/src/fixes/pause_on_focus_loss.cpp
@@ -8,7 +8,7 @@
 
 bool PauseOnFocusLoss::ShouldFixPauseState()
 {
-    return g_PauseOnFocusLoss.bPauseOnFocusLoss ? (g_GameVars.InCutscene() || g_GameVars.InPadDemo()) : true;
+    return g_PauseOnFocusLoss.bPauseOnFocusLoss ? (g_GameVars.InCutscene() || g_GameVars.InScriptedSequence()) : true;
 }
 
 void PauseOnFocusLoss::Initialize()

--- a/src/fixes/water_reflections.cpp
+++ b/src/fixes/water_reflections.cpp
@@ -31,12 +31,7 @@ void WaterReflectionFix::Initialize() const
         if (MGS3_RenderWaterSurfaceScanResult && MGS3_RenderWaterSurfaceScanAddress)
         {
             MGS3_RenderWaterSurface_hook = safetyhook::create_inline(reinterpret_cast<void*>(MGS3_RenderWaterSurfaceScanAddress), reinterpret_cast<void*>(MGS3_RenderWaterSurface));
-            if (!MGS3_RenderWaterSurface_hook)
-            {
-                spdlog::info("MGS 3: Render Water Surface: Hook failed.");
-                return;
-            }
-            spdlog::info("MGS 3: Render Water Surface: Hook successful. Address is {:s}+{:x}", sExeName.c_str(), MGS3_RenderWaterSurfaceScanAddress - (uintptr_t)baseModule);
+            LOG_HOOK(MGS3_RenderWaterSurface_hook, "MGS 3: Render Water Surface")
         }
         else
         {
@@ -48,12 +43,7 @@ void WaterReflectionFix::Initialize() const
         if (MGS3_GetViewportCameraOffsetYScanResult && MGS3_GetViewportCameraOffsetYScanAddress)
         {
             MGS3_GetViewportCameraOffsetY_hook = safetyhook::create_inline(reinterpret_cast<void*>(MGS3_GetViewportCameraOffsetYScanAddress), reinterpret_cast<void*>(MGS3_GetViewportCameraOffsetY));
-            if (!MGS3_GetViewportCameraOffsetY_hook)
-            {
-                spdlog::info("MGS 3: Get Viewport Camera Offset: Hook failed.");
-                return;
-            }
-            spdlog::info("MGS 3: Get Viewport Camera Offset: Hook successful. Address is {:s}+{:x}", sExeName.c_str(), MGS3_GetViewportCameraOffsetYScanAddress - (uintptr_t)baseModule);
+            LOG_HOOK(MGS3_GetViewportCameraOffsetY_hook, "MGS 3: Get Viewport Camera Offset")
         }
         else
         {

--- a/src/resources/common.hpp
+++ b/src/resources/common.hpp
@@ -3,11 +3,13 @@
 
 #include <map>
 
-extern std::string const sFixVersion;
-extern std::string sExeName;
-extern std::filesystem::path sGameSavePath;
+inline std::string sExeName;
+inline std::filesystem::path sExePath;
+inline std::filesystem::path sGameSavePath;
 
-extern HMODULE engineModule;
+inline HMODULE baseModule = GetModuleHandle(NULL);
+inline HMODULE engineModule;
+inline HMODULE unityPlayer;
 
 
 struct GameInfo
@@ -16,7 +18,7 @@ struct GameInfo
     std::string ExeName;
     int SteamAppId;
 };
-extern const GameInfo* game;
+inline const GameInfo* game = nullptr;
 
 enum MgsGame : std::uint8_t
 {
@@ -27,19 +29,10 @@ enum MgsGame : std::uint8_t
     LAUNCHER = 1 << 3,
     UNKNOWN  = 1 << 4
 };
-extern const std::map<MgsGame, GameInfo> kGames;
-extern MgsGame eGameType;
+inline MgsGame eGameType = UNKNOWN;
 
-extern HMODULE baseModule;
-extern std::string sGameVersion;
-extern std::filesystem::path sExePath;
-extern std::string sFixName;
-
-
-//Config Options
-extern int iOutputResY;
-extern int iInternalResY;
-extern float fAspectRatio;
-extern bool bOutdatedReshade;
-extern bool bLauncherConfigSkipLauncher;
-
+inline const std::map<MgsGame, GameInfo> kGames = {
+    {MGS2, {"Metal Gear Solid 2 MC", "METAL GEAR SOLID2.exe", 2131640}},
+    {MGS3, {"Metal Gear Solid 3 MC", "METAL GEAR SOLID3.exe", 2131650}},
+    {MG, {"Metal Gear / Metal Gear 2 (MSX)", "METAL GEAR.exe", 2131680}},
+};

--- a/src/resources/config.cpp
+++ b/src/resources/config.cpp
@@ -1,0 +1,200 @@
+#include "common.hpp"
+#include "config.hpp"
+
+#include <inipp/inipp.h>
+
+#include "intro_skip.hpp"
+#include "line_scaling.hpp"
+#include "logging.hpp"
+#include "mute_warning.hpp"
+#include "pause_on_focus_loss.hpp"
+#include "steamworks_api.hpp"
+#include "stereo_audio.hpp"
+#include "texture_buffer_size.hpp"
+#include "version_checking.hpp"
+#include "stat_persistence.hpp"
+
+
+void Config::Read()
+{
+    std::filesystem::path sConfigFile = sFixName + ".ini";
+
+    std::ifstream iniFile((sExePath / sFixPath / sConfigFile).string());
+    if (!iniFile)
+    {
+        spdlog::error("CONFIG ERROR: File not found: {}", (sExePath / sFixPath / sConfigFile).string());
+        Logging::ShowConsole();
+        std::cout << "" << sFixName << " v" << sFixVersion << " loaded." << std::endl;
+        std::cout << "ERROR: Could not locate config file." << std::endl;
+        std::cout << "ERROR: Make sure " << sConfigFile << " is located in " << sExePath / sFixPath << std::endl;
+        return FreeLibraryAndExitThread(baseModule, 1);
+    }
+
+    spdlog::info("Config file: {}", (sExePath / sFixPath / sConfigFile).string());
+
+    inipp::Ini<char> ini;
+    ini.parse(iniFile);
+    if (!ini.errors.empty())
+    {
+        spdlog::error("Error parsing ini file, encountered {} errors at these lines:", ini.errors.size());
+        Logging::ShowConsole();
+        std::cout << "Error parsing ini file, encountered " << ini.errors.size() << " errors at these lines:" << std::endl;
+        for (auto err : ini.errors)
+        {
+            spdlog::error(err);
+            std::cout << err << std::endl;
+        }
+    }
+
+    int loadedConfigVersion;
+    inipp::get_value(ini.sections["Config Version"], "Version", loadedConfigVersion);
+    if (loadedConfigVersion != iConfigVersion)
+    {
+        spdlog::error("CONFIG ERROR: Config file version mismatch! Expected version {}, but found version {}.", iConfigVersion, loadedConfigVersion);
+        Logging::ShowConsole();
+        std::cout << "" << sFixName << " v" << sFixVersion << " loaded." << std::endl;
+        std::cout << "MGSHDFix CONFIG ERROR: Outdated config file!" << std::endl;
+        std::cout << "MGSHDFix CONFIG ERROR: Please install -all- the files from the latest release!" << std::endl;
+        return FreeLibraryAndExitThread(baseModule, 1);
+    }
+
+    // Grab desktop resolution
+    DesktopDimensions = Util::GetPhysicalDesktopDimensions();
+
+    // Read ini file
+    g_Logging.bVerboseLogging = Util::stringToBool(ini.sections["Verbose Logging"]["Enabled"]);
+    bOutputResolution = Util::stringToBool(ini.sections["Output Resolution"]["Enabled"]);
+    inipp::get_value(ini.sections["Output Resolution"], "Width", iOutputResX);
+    inipp::get_value(ini.sections["Output Resolution"], "Height", iOutputResY);
+    bWindowedMode = Util::stringToBool(ini.sections["Output Resolution"]["Windowed"]);
+    bBorderlessMode = Util::stringToBool(ini.sections["Output Resolution"]["Borderless"]);
+    inipp::get_value(ini.sections["Internal Resolution"], "Width", iInternalResX);
+    inipp::get_value(ini.sections["Internal Resolution"], "Height", iInternalResY);
+    inipp::get_value(ini.sections["Anisotropic Filtering"], "Samples", iAnisotropicFiltering);
+    bDisableTextureFiltering = Util::stringToBool(ini.sections["Disable Texture Filtering"]["DisableTextureFiltering"]);
+    bFramebufferFix = Util::stringToBool(ini.sections["Framebuffer Fix"]["Enabled"]);
+    bLauncherJumpStart = Util::stringToBool(ini.sections["Launcher Config"]["LauncherJumpStart"]);
+    g_IntroSkip.isEnabled = Util::stringToBool(ini.sections["Skip Intro Logos"]["Enabled"]);
+    g_StereoAudioFix.isEnabled = Util::stringToBool(ini.sections["Force Stereo Audio"]["Enabled"]);
+    g_PauseOnFocusLoss.bPauseOnFocusLoss = Util::stringToBool(ini.sections["Pause On Focus Loss"]["Enabled"]);
+    g_PauseOnFocusLoss.bSpeedrunnerBugfixOverride = Util::stringToBool(ini.sections["Pause On Focus Loss"]["SpeedrunnerBugfixOverride"]);
+    g_MuteWarning.bEnabled = Util::stringToBool(ini.sections["Mute Warning"]["Enabled"]);
+
+    bShouldCheckForUpdates = Util::stringToBool(ini.sections["Update Notifications"]["CheckForUpdates"]);
+    bConsoleUpdateNotifications = Util::stringToBool(ini.sections["Update Notifications"]["ConsoleNotifications"]);
+    g_StatPersistence.bAchievementPersistenceEnabled = Util::stringToBool(ini.sections["Achievement Persistence"]["Enabled"]);
+    g_SteamAPI.bResetAchievements = Util::stringToBool(ini.sections["Reset All Achievements"]["Reset_All_Achievements"]);
+
+    /*//INITIALIZE(Init_GammaShader());
+    //INITIALIZE(g_DistanceCulling.Initialize());
+    //INITIALIZE(g_MultiSampleAntiAliasing.Initialize());
+    //INITIALIZE(g_Wireframe.Initialize());
+
+    //INITIALIZE(g_AimAfterEquipFix.Initialize());
+    //INITIALIZE(g_ColorFilterFix.Initialize());*/
+
+    //inipp::get_value(ini.sections["MG1 Custom Loading Screens"], "Enabled", g_MG1CustomLoadingScreens.isEnabled);
+    bMouseSensitivity = Util::stringToBool(ini.sections["Mouse Sensitivity"]["Enabled"]);
+    inipp::get_value(ini.sections["Mouse Sensitivity"], "X Multiplier", fMouseSensitivityXMulti);
+    inipp::get_value(ini.sections["Mouse Sensitivity"], "Y Multiplier", fMouseSensitivityYMulti);
+    bDisableCursor = Util::stringToBool(ini.sections["Disable Mouse Cursor"]["Enabled"]);
+    inipp::get_value(ini.sections["Texture Buffer"], "SizeMB", g_TextureBufferSize.iTextureBufferSizeMB);
+    bAspectFix = Util::stringToBool(ini.sections["Fix Aspect Ratio"]["Enabled"]);
+    bHUDFix = Util::stringToBool(ini.sections["Fix HUD"]["Enabled"]);
+    bFOVFix = Util::stringToBool(ini.sections["Fix FOV"]["Enabled"]);
+    bLauncherConfigSkipLauncher = Util::stringToBool(ini.sections["Launcher Config"]["SkipLauncher"]);
+
+    // Read launcher settings from ini
+    std::string sLauncherConfigCtrlType = "kbd";
+    std::string sLauncherConfigRegion = "us";
+    std::string sLauncherConfigLanguage = "en";
+    inipp::get_value(ini.sections["Launcher Config"], "CtrlType", sLauncherConfigCtrlType);
+    inipp::get_value(ini.sections["Launcher Config"], "Region", sLauncherConfigRegion);
+    inipp::get_value(ini.sections["Launcher Config"], "Language", sLauncherConfigLanguage);
+    inipp::get_value(ini.sections["Launcher Config"], "MSXGame", sLauncherConfigMSXGame);
+    inipp::get_value(ini.sections["Launcher Config"], "MSXWallType", iLauncherConfigMSXWallType);
+    inipp::get_value(ini.sections["Launcher Config"], "MSXWallAlign", sLauncherConfigMSXWallAlign);
+    iLauncherConfigCtrlType = Util::findStringInVector(sLauncherConfigCtrlType, kLauncherConfigCtrlTypes);
+    iLauncherConfigRegion = Util::findStringInVector(sLauncherConfigRegion, kLauncherConfigRegions);
+    iLauncherConfigLanguage = Util::findStringInVector(sLauncherConfigLanguage, kLauncherConfigLanguages);
+
+
+
+    // Log config parse
+    spdlog::info("Config Parse: Verbose Logging: {}", g_Logging.bVerboseLogging);
+    spdlog::info("Config Parse: Custom Output Resolution: {}", bOutputResolution);
+    if (iOutputResX == 0 || iOutputResY == 0)
+    {
+        iOutputResX = DesktopDimensions.first;
+        iOutputResY = DesktopDimensions.second;
+    }
+    spdlog::info("Config Parse: Output Resolution (X): {}", iOutputResX);
+    spdlog::info("Config Parse: Output Resolution (Y): {}", iOutputResY);
+    if (iInternalResX == 0 || iInternalResY == 0)
+    {
+        iInternalResX = iOutputResX;
+        iInternalResY = iOutputResY;
+    }
+    spdlog::info("Config Parse: Internal Resolution (X): {}", iInternalResX);
+    spdlog::info("Config Parse: Internal Resolution (Y): {}", iInternalResY);
+    spdlog::info("Config Parse: Windowed Mode: {}", bWindowedMode);
+    spdlog::info("Config Parse: Borderless Mode: {}", bBorderlessMode);
+    spdlog::info("Config Parse: Fix Ultrawide Framebuffer: {}", bFramebufferFix);
+    spdlog::info("Config Parse: Fix Ultrawide Aspect Ratio: {}", bAspectFix);
+    spdlog::info("Config Parse: Fix Ultrawide HUD: {}", bHUDFix);
+    spdlog::info("Config Parse: Fix Ultrawide FOV: {}", bFOVFix);
+    spdlog::info("Config Parse: Texture Buffer Size (PER TEXTURE): {}MB", g_TextureBufferSize.iTextureBufferSizeMB); //g_TextureBufferSize
+    spdlog::info("Config Parse: Anisotropic Filtering Level: {}", iAnisotropicFiltering);
+    if (iAnisotropicFiltering < 0 || iAnisotropicFiltering > 16)
+    {
+        iAnisotropicFiltering = std::clamp(iAnisotropicFiltering, 0, 16);
+        spdlog::info("Config Parse: Anisotropic Filtering value invalid, clamped to {}", iAnisotropicFiltering);
+    }
+    spdlog::info("Config Parse: Disable Texture Filtering: {}", bDisableTextureFiltering);
+    spdlog::info("Config Parse: Disable Cursor Icon: {}", bDisableCursor);
+    spdlog::info("Config Parse: Mouse Sensitivity: {}", bMouseSensitivity);
+    spdlog::info("Config Parse: Mouse Sensitivity X Multiplier: {}", fMouseSensitivityXMulti);
+    spdlog::info("Config Parse: Mouse Sensitivity Y Multiplier: {}", fMouseSensitivityYMulti);
+
+
+    //spdlog::info("Config Parse: bMG1CustomLoadingScreens: {}", g_MG1CustomLoadingScreens.isEnabled);
+
+    spdlog::info("Config Parse: Launcher Jump Start: {}", bLauncherJumpStart);
+
+    spdlog::info("Config Parse: Launcher - Skip Launcher: {}", bLauncherConfigSkipLauncher);
+    spdlog::info("Config Parse: Launcher - Controller Glyphs: {} ( {} )", iLauncherConfigCtrlType, Util::GetUppercaseNameAtIndex(kLauncherConfigCtrlTypes, iLauncherConfigCtrlType));
+    spdlog::info("Config Parse: Launcher - MSX Game: {}", sLauncherConfigMSXGame);
+    spdlog::info("Config Parse: Launcher - Region: {} ({})", iLauncherConfigRegion, Util::GetUppercaseNameAtIndex(kLauncherConfigRegions, iLauncherConfigRegion));
+    spdlog::info("Config Parse: Launcher - Language: {} ({})", iLauncherConfigLanguage, Util::GetUppercaseNameAtIndex(kLauncherConfigLanguages, iLauncherConfigLanguage));
+    if (std::string ps2Str = "ps2"; (iLauncherConfigCtrlType == Util::findStringInVector(ps2Str, kLauncherConfigCtrlTypes)))
+    {
+        bIsPS2controltype = true;
+        ps2Str = "ps4";
+        iLauncherConfigCtrlType = Util::findStringInVector(ps2Str, kLauncherConfigCtrlTypes);
+    }
+    spdlog::info("Config Parse: Skip Intro Videos: {}", g_IntroSkip.isEnabled);
+    spdlog::info("Config Parse: Pause On Focus Loss: {}", g_PauseOnFocusLoss.bPauseOnFocusLoss);
+    spdlog::info("Config Parse: Cutscene Asset Loading Fix - Speedrunner Override: {}", g_PauseOnFocusLoss.bSpeedrunnerBugfixOverride);
+
+    spdlog::info("Config Parse: Force Stereo Audio: {}", g_StereoAudioFix.isEnabled);
+    spdlog::info("Config Parse: Muted Audio Console Warnings: {}", g_MuteWarning.bEnabled);
+    if (eGameType & (MGS2 | MGS3))
+    {
+        g_VectorScalingFix.bEnableVectorLineFix = Util::stringToBool(ini.sections["Vector Line Fix"]["Enabled"]);
+        spdlog::info("Config Parse: Fix Vector Effect (Rain) Scaling: {}", g_VectorScalingFix.bEnableVectorLineFix);
+        if (g_VectorScalingFix.bEnableVectorLineFix)
+        {
+            inipp::get_value(ini.sections["Vector Line Fix"], "Line Scale", g_VectorScalingFix.iVectorLineScale);
+            spdlog::info("Config Parse: Vector Effect Width: {} / {} pixels wide.", g_VectorScalingFix.iVectorLineScale, iInternalResY / g_VectorScalingFix.iVectorLineScale);
+        }
+    }
+
+    spdlog::info("Cofig Parse: Check for mod updates: {}", bShouldCheckForUpdates);
+    if (bShouldCheckForUpdates)
+    {
+        spdlog::info("Cofig Parse: Mod update console notifications: {}", bConsoleUpdateNotifications);
+    }
+
+    spdlog::info("Config Parse: Achievement Persistence: {}", g_StatPersistence.bAchievementPersistenceEnabled);
+    spdlog::info("Config Parse: Reset Achievements: {}", g_SteamAPI.bResetAchievements);
+}

--- a/src/resources/config.cpp
+++ b/src/resources/config.cpp
@@ -15,6 +15,75 @@
 #include "stat_persistence.hpp"
 
 
+// -----------------------------------------------------------------------------
+// ConfigHelper: A type-safe, case-insensitive, error-checked INI config reader.
+// Automatically logs missing/invalid values and exits the thread immediately.
+// By Afevis/ShizCalev, 2025.
+// -----------------------------------------------------------------------------
+
+namespace ConfigHelper
+{
+    /// Terminates execution with a fatal INI error
+    inline void FatalConfigError(const std::string& section, const std::string& key, const std::string& reason)
+    {
+        std::string message = "[" + sFixName +  " Config Helper] Failed to read config key '" + key +
+            "' in section '" + section + "': " + reason;
+
+        spdlog::error(message);
+        spdlog::error("Please check that you're using the latest version's config file, and that there are no typos in it.");
+        Logging::ShowConsole();
+        std::cout << message << std::endl;
+        std::cout << "Please check that you're using the latest version's config file, and that there are no typos in it." << std::endl;
+
+        FreeLibraryAndExitThread(baseModule, 1);
+    }
+
+    /// Internal parsing helper
+    template <typename T>
+    bool TryParse(const std::string& str, T& out)
+    {
+        std::istringstream iss(str);
+        return (iss >> std::boolalpha >> out) ? true : false;
+    }
+
+    /// Parses bool values with case-insensitivity and common boolean strings
+    template <>
+    inline bool TryParse<bool>(const std::string& str, bool& out)
+    {
+        std::string val = str;
+        std::transform(val.begin(), val.end(), val.begin(), ::tolower);
+        if (val == "1" || val == "true" || val == "yes" || val == "on")
+        {
+            out = true;
+            return true;
+        }
+        if (val == "0" || val == "false" || val == "no" || val == "off")
+        {
+            out = false;
+            return true;
+        }
+        return false;
+    }
+
+    /// Generic value loader from INI with hard error on failure
+    template <typename T>
+    void getValue(const inipp::Ini<char>& ini, const std::string& section, const std::string& key, T& out)
+    {
+        auto secIt = ini.sections.find(section);
+        if (secIt == ini.sections.end())
+            FatalConfigError(section, key, "Section not found");
+
+        const auto& keyvals = secIt->second;
+        auto keyIt = keyvals.find(key);
+        if (keyIt == keyvals.end())
+            FatalConfigError(section, key, "Key not found");
+
+        if (!TryParse<T>(keyIt->second, out))
+            FatalConfigError(section, key, "Failed to parse value '" + keyIt->second + "'");
+    }
+}
+
+
 void Config::Read()
 {
     std::filesystem::path sConfigFile = sFixName + ".ini";
@@ -46,44 +115,44 @@ void Config::Read()
         }
     }
 
-    int loadedConfigVersion;
-    inipp::get_value(ini.sections["Config Version"], "Version", loadedConfigVersion);
-    if (loadedConfigVersion != iConfigVersion)
-    {
-        spdlog::error("CONFIG ERROR: Config file version mismatch! Expected version {}, but found version {}.", iConfigVersion, loadedConfigVersion);
-        Logging::ShowConsole();
-        std::cout << "" << sFixName << " v" << sFixVersion << " loaded." << std::endl;
-        std::cout << "MGSHDFix CONFIG ERROR: Outdated config file!" << std::endl;
-        std::cout << "MGSHDFix CONFIG ERROR: Please install -all- the files from the latest release!" << std::endl;
-        return FreeLibraryAndExitThread(baseModule, 1);
-    }
-
     // Grab desktop resolution
     DesktopDimensions = Util::GetPhysicalDesktopDimensions();
 
     // Read ini file
-    g_Logging.bVerboseLogging = Util::stringToBool(ini.sections["Verbose Logging"]["Enabled"]);
-    bOutputResolution = Util::stringToBool(ini.sections["Output Resolution"]["Enabled"]);
-    inipp::get_value(ini.sections["Output Resolution"], "Width", iOutputResX);
-    inipp::get_value(ini.sections["Output Resolution"], "Height", iOutputResY);
-    bWindowedMode = Util::stringToBool(ini.sections["Output Resolution"]["Windowed"]);
-    bBorderlessMode = Util::stringToBool(ini.sections["Output Resolution"]["Borderless"]);
-    inipp::get_value(ini.sections["Internal Resolution"], "Width", iInternalResX);
-    inipp::get_value(ini.sections["Internal Resolution"], "Height", iInternalResY);
-    inipp::get_value(ini.sections["Anisotropic Filtering"], "Samples", iAnisotropicFiltering);
-    bDisableTextureFiltering = Util::stringToBool(ini.sections["Disable Texture Filtering"]["DisableTextureFiltering"]);
-    bFramebufferFix = Util::stringToBool(ini.sections["Framebuffer Fix"]["Enabled"]);
-    bLauncherJumpStart = Util::stringToBool(ini.sections["Launcher Config"]["LauncherJumpStart"]);
-    g_IntroSkip.isEnabled = Util::stringToBool(ini.sections["Skip Intro Logos"]["Enabled"]);
-    g_StereoAudioFix.isEnabled = Util::stringToBool(ini.sections["Force Stereo Audio"]["Enabled"]);
-    g_PauseOnFocusLoss.bPauseOnFocusLoss = Util::stringToBool(ini.sections["Pause On Focus Loss"]["Enabled"]);
-    g_PauseOnFocusLoss.bSpeedrunnerBugfixOverride = Util::stringToBool(ini.sections["Pause On Focus Loss"]["SpeedrunnerBugfixOverride"]);
-    g_MuteWarning.bEnabled = Util::stringToBool(ini.sections["Mute Warning"]["Enabled"]);
+    ConfigHelper::getValue(ini, "Verbose Logging", "Enabled", g_Logging.bVerboseLogging);
 
-    bShouldCheckForUpdates = Util::stringToBool(ini.sections["Update Notifications"]["CheckForUpdates"]);
-    bConsoleUpdateNotifications = Util::stringToBool(ini.sections["Update Notifications"]["ConsoleNotifications"]);
-    g_StatPersistence.bAchievementPersistenceEnabled = Util::stringToBool(ini.sections["Achievement Persistence"]["Enabled"]);
-    g_SteamAPI.bResetAchievements = Util::stringToBool(ini.sections["Reset All Achievements"]["Reset_All_Achievements"]);
+    ConfigHelper::getValue(ini, "Output Resolution", "Enabled", bOutputResolution);
+    ConfigHelper::getValue(ini, "Output Resolution", "Width", iOutputResX);
+    ConfigHelper::getValue(ini, "Output Resolution", "Height", iOutputResY);
+    ConfigHelper::getValue(ini, "Output Resolution", "Windowed", bWindowedMode);
+    ConfigHelper::getValue(ini, "Output Resolution", "Borderless", bBorderlessMode);
+
+    ConfigHelper::getValue(ini, "Internal Resolution", "Width", iInternalResX);
+    ConfigHelper::getValue(ini, "Internal Resolution", "Height", iInternalResY);
+
+    ConfigHelper::getValue(ini, "Anisotropic Filtering", "Samples", iAnisotropicFiltering);
+
+    ConfigHelper::getValue(ini, "Disable Texture Filtering", "DisableTextureFiltering", bDisableTextureFiltering);
+
+    ConfigHelper::getValue(ini, "Framebuffer Fix", "Enabled", bFramebufferFix);
+
+    ConfigHelper::getValue(ini, "Launcher Config", "LauncherJumpStart", bLauncherJumpStart);
+
+    ConfigHelper::getValue(ini, "Skip Intro Logos", "Enabled", g_IntroSkip.isEnabled);
+    ConfigHelper::getValue(ini, "Force Stereo Audio", "Enabled", g_StereoAudioFix.isEnabled);
+
+    ConfigHelper::getValue(ini, "Pause On Focus Loss", "Enabled", g_PauseOnFocusLoss.bPauseOnFocusLoss);
+    ConfigHelper::getValue(ini, "Pause On Focus Loss", "SpeedrunnerBugfixOverride", g_PauseOnFocusLoss.bSpeedrunnerBugfixOverride);
+
+    ConfigHelper::getValue(ini, "Mute Warning", "Enabled", g_MuteWarning.bEnabled);
+
+    ConfigHelper::getValue(ini, "Update Notifications", "CheckForUpdates", bShouldCheckForUpdates);
+    ConfigHelper::getValue(ini, "Update Notifications", "ConsoleNotifications", bConsoleUpdateNotifications);
+
+    ConfigHelper::getValue(ini, "Achievement Persistence", "Enabled", g_StatPersistence.bAchievementPersistenceEnabled);
+
+    ConfigHelper::getValue(ini, "Reset All Achievements", "Reset_All_Achievements", g_SteamAPI.bResetAchievements);
+
 
     /*//INITIALIZE(Init_GammaShader());
     //INITIALIZE(g_DistanceCulling.Initialize());
@@ -94,26 +163,31 @@ void Config::Read()
     //INITIALIZE(g_ColorFilterFix.Initialize());*/
 
     //inipp::get_value(ini.sections["MG1 Custom Loading Screens"], "Enabled", g_MG1CustomLoadingScreens.isEnabled);
-    bMouseSensitivity = Util::stringToBool(ini.sections["Mouse Sensitivity"]["Enabled"]);
-    inipp::get_value(ini.sections["Mouse Sensitivity"], "X Multiplier", fMouseSensitivityXMulti);
-    inipp::get_value(ini.sections["Mouse Sensitivity"], "Y Multiplier", fMouseSensitivityYMulti);
-    bDisableCursor = Util::stringToBool(ini.sections["Disable Mouse Cursor"]["Enabled"]);
-    inipp::get_value(ini.sections["Texture Buffer"], "SizeMB", g_TextureBufferSize.iTextureBufferSizeMB);
-    bAspectFix = Util::stringToBool(ini.sections["Fix Aspect Ratio"]["Enabled"]);
-    bHUDFix = Util::stringToBool(ini.sections["Fix HUD"]["Enabled"]);
-    bFOVFix = Util::stringToBool(ini.sections["Fix FOV"]["Enabled"]);
-    bLauncherConfigSkipLauncher = Util::stringToBool(ini.sections["Launcher Config"]["SkipLauncher"]);
+    ConfigHelper::getValue(ini, "Mouse Sensitivity", "Enabled", bMouseSensitivity);
+    ConfigHelper::getValue(ini, "Mouse Sensitivity", "X Multiplier", fMouseSensitivityXMulti);
+    ConfigHelper::getValue(ini, "Mouse Sensitivity", "Y Multiplier", fMouseSensitivityYMulti);
+
+    ConfigHelper::getValue(ini, "Disable Mouse Cursor", "Enabled", bDisableCursor);
+
+    ConfigHelper::getValue(ini, "Texture Buffer", "SizeMB", g_TextureBufferSize.iTextureBufferSizeMB);
+
+    ConfigHelper::getValue(ini, "Fix Aspect Ratio", "Enabled", bAspectFix);
+    ConfigHelper::getValue(ini, "Fix HUD", "Enabled", bHUDFix);
+    ConfigHelper::getValue(ini, "Fix FOV", "Enabled", bFOVFix);
+
+    ConfigHelper::getValue(ini, "Launcher Config", "SkipLauncher", bLauncherConfigSkipLauncher);
+
 
     // Read launcher settings from ini
     std::string sLauncherConfigCtrlType = "kbd";
     std::string sLauncherConfigRegion = "us";
     std::string sLauncherConfigLanguage = "en";
-    inipp::get_value(ini.sections["Launcher Config"], "CtrlType", sLauncherConfigCtrlType);
-    inipp::get_value(ini.sections["Launcher Config"], "Region", sLauncherConfigRegion);
-    inipp::get_value(ini.sections["Launcher Config"], "Language", sLauncherConfigLanguage);
-    inipp::get_value(ini.sections["Launcher Config"], "MSXGame", sLauncherConfigMSXGame);
-    inipp::get_value(ini.sections["Launcher Config"], "MSXWallType", iLauncherConfigMSXWallType);
-    inipp::get_value(ini.sections["Launcher Config"], "MSXWallAlign", sLauncherConfigMSXWallAlign);
+    ConfigHelper::getValue(ini, "Launcher Config", "CtrlType", sLauncherConfigCtrlType);
+    ConfigHelper::getValue(ini, "Launcher Config", "Region", sLauncherConfigRegion);
+    ConfigHelper::getValue(ini, "Launcher Config", "Language", sLauncherConfigLanguage);
+    ConfigHelper::getValue(ini, "Launcher Config", "MSXGame", sLauncherConfigMSXGame);
+    ConfigHelper::getValue(ini, "Launcher Config", "MSXWallType", iLauncherConfigMSXWallType);
+    ConfigHelper::getValue(ini, "Launcher Config", "MSXWallAlign", sLauncherConfigMSXWallAlign);
     iLauncherConfigCtrlType = Util::findStringInVector(sLauncherConfigCtrlType, kLauncherConfigCtrlTypes);
     iLauncherConfigRegion = Util::findStringInVector(sLauncherConfigRegion, kLauncherConfigRegions);
     iLauncherConfigLanguage = Util::findStringInVector(sLauncherConfigLanguage, kLauncherConfigLanguages);
@@ -180,7 +254,7 @@ void Config::Read()
     spdlog::info("Config Parse: Muted Audio Console Warnings: {}", g_MuteWarning.bEnabled);
     if (eGameType & (MGS2 | MGS3))
     {
-        g_VectorScalingFix.bEnableVectorLineFix = Util::stringToBool(ini.sections["Vector Line Fix"]["Enabled"]);
+        ConfigHelper::getValue(ini, "Vector Line Fix", "Enabled", g_VectorScalingFix.bEnableVectorLineFix);
         spdlog::info("Config Parse: Fix Vector Effect (Rain) Scaling: {}", g_VectorScalingFix.bEnableVectorLineFix);
         if (g_VectorScalingFix.bEnableVectorLineFix)
         {

--- a/src/resources/config.hpp
+++ b/src/resources/config.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+class Config final
+{
+public:
+    static void Read();
+};
+
+
+
+inline float fAspectRatio;
+inline bool bAspectFix;
+inline bool bHUDFix;
+inline bool bFOVFix;
+inline bool bOutputResolution;
+inline int iOutputResX;
+inline int iOutputResY;
+inline int iInternalResX;
+inline int iInternalResY;
+inline bool bWindowedMode;
+inline bool bBorderlessMode;
+inline bool bFramebufferFix;
+inline bool bLauncherJumpStart;
+inline int iAnisotropicFiltering;
+inline bool bDisableTextureFiltering;
+inline bool bMouseSensitivity;
+inline float fMouseSensitivityXMulti;
+inline float fMouseSensitivityYMulti;
+inline bool bDisableCursor;
+
+inline bool bIsPS2controltype = false;
+
+// Launcher ini variables
+inline bool bLauncherConfigSkipLauncher = false;
+inline int iLauncherConfigCtrlType = 5;
+inline int iLauncherConfigRegion = 0;
+inline int iLauncherConfigLanguage = 0;
+inline std::string sLauncherConfigMSXGame = "mg1";
+inline int iLauncherConfigMSXWallType = 0;
+inline std::string sLauncherConfigMSXWallAlign = "C";
+
+
+inline const std::initializer_list<std::string> kLauncherConfigCtrlTypes = {
+    "ps5",
+    "ps4",
+    "xbox",
+    "nx",
+    "stmd",
+    "kbd",
+    "ps2"
+};
+
+inline const std::initializer_list<std::string> kLauncherConfigLanguages = {
+    "en",
+    "jp",
+    "fr",
+    "gr",
+    "it",
+    "pr",
+    "sp",
+    "du",
+    "ru"
+};
+
+inline const std::initializer_list<std::string> kLauncherConfigRegions = {
+    "us",
+    "jp",
+    "eu"
+};
+
+inline std::pair DesktopDimensions = { 0,0 };

--- a/src/resources/d3d11_api.cpp
+++ b/src/resources/d3d11_api.cpp
@@ -5,11 +5,14 @@
 #pragma comment(lib,"d3d11.lib")
 #pragma comment(lib, "dxgi.lib")
 
-extern void preD3D11CreateDevice();
-extern void afterD3D11CreateDevice();
 
-extern void preCreateDXGIFactory();
-extern void afterCreateDXGIFactory();
+void preD3D11CreateDevice();
+void afterD3D11CreateDevice();
+
+void preCreateDXGIFactory();
+void afterCreateDXGIFactory();
+
+
 namespace
 {
     // D3D11CreateDevice Hook
@@ -85,6 +88,6 @@ void D3D11Hooks::Initialize()
 {
     D3D11CreateDevice_hook = safetyhook::create_inline(D3D11CreateDevice, reinterpret_cast<void*>(D3D11CreateDevice_hooked));
     LOG_HOOK(D3D11CreateDevice_hook, "MG/MG2 | MGS 2 | MGS 3: D3D11CreateDevice: Hooked function.")
-        CreateDXGIFactory_hook = safetyhook::create_inline(CreateDXGIFactory, reinterpret_cast<void*>(CreateDXGIFactory_hooked));
+    CreateDXGIFactory_hook = safetyhook::create_inline(CreateDXGIFactory, reinterpret_cast<void*>(CreateDXGIFactory_hooked));
     LOG_HOOK(CreateDXGIFactory_hook, "MG/MG2 | MGS 2 | MGS 3: CreateDXGIFactory: Hooked function.")
 }

--- a/src/resources/gamevars.cpp
+++ b/src/resources/gamevars.cpp
@@ -9,8 +9,8 @@ void GameVars::Initialize()
 {
     if (eGameType & MGS2)
     {
-        cutsceneFlag = reinterpret_cast<int*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "44 39 35 ?? ?? ?? ?? 89 15", "MGS 2: GameVars: cutsceneFlag") + 3));
-        padDemoFlag = reinterpret_cast<int*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "8B 05 ?? ?? ?? ?? 45 33 F6 8B 0D", "MGS 2: GameVars: padDemoFlag") + 2));
+        cutsceneFlag = reinterpret_cast<int*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "8B 05 ?? ?? ?? ?? 45 33 F6 8B 0D", "MGS 2: GameVars: cutsceneFlag") + 2));
+        scriptedSequenceFlag = reinterpret_cast<int*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "44 39 35 ?? ?? ?? ?? 89 15", "MGS 2: GameVars: scriptedSequenceFlag") + 3));
         actorWaitValue = reinterpret_cast<double*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "66 0F 2F 05 ?? ?? ?? ?? 73 ?? 33 C0", "MGS 2: GameVars: actorWaitValue") + 4));
         currentStage = reinterpret_cast<char const*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "4C 8D 0D ?? ?? ?? ?? 48 8D 15 ?? ?? ?? ?? 4C 8D 05", "MGS 2: GameVars: currentStage") + 3));
         if (uint8_t* LevelTransitionResult = Memory::PatternScan(baseModule, "89 73 ?? 81 25", "GameVars: Level Transition"))
@@ -39,14 +39,14 @@ void GameVars::Initialize()
     }
 }
 
-bool GameVars::InCutscene() const
+bool GameVars::InCutscene() const //does not count pad demos or FMVs, only full cutscenes.
 {
     return cutsceneFlag == nullptr ? false : (*cutsceneFlag == 1);
 }
 
-bool GameVars::InPadDemo() const
+bool GameVars::InScriptedSequence() const //Scripted sequences, i.e., forced codec calls, cutscenes, pad demos (ingame tutorials & forced movements ala first meeting Stillman), and FMVs.
 {
-    return padDemoFlag == nullptr ? false : (*padDemoFlag == 1);
+    return scriptedSequenceFlag == nullptr ? false : (*scriptedSequenceFlag == 1);
 }
 
 double GameVars::ActorWaitMultiplier() const

--- a/src/resources/gamevars.hpp
+++ b/src/resources/gamevars.hpp
@@ -6,14 +6,14 @@ private:
     static void OnLevelTransition();
 
     int* cutsceneFlag = nullptr;
-    int* padDemoFlag = nullptr;
+    int* scriptedSequenceFlag = nullptr;
     double* actorWaitValue = nullptr;
     const char* currentStage = nullptr;
 
 public:
     void Initialize();
-    bool InCutscene() const;
-    bool InPadDemo() const;
+    bool InCutscene() const; // If we're in a full demo cutscene.
+    bool InScriptedSequence() const; // If the game is in a scripted sequence (cutscene or pad demo).
     double ActorWaitMultiplier() const;
     const char* GetCurrentStage() const;
 };

--- a/src/resources/gpu_check.cpp
+++ b/src/resources/gpu_check.cpp
@@ -110,6 +110,26 @@ namespace
         }
     } tableSorter;
 
+    std::string SanitizeGPUName(const std::string& name)
+    {
+        std::string sanitized = name;
+        // Use regex to remove (c), (r), (tm) case insensitive, with optional spaces inside parentheses
+        std::regex trademark_re(R"(\(\s*(c|r|tm)\s*\))", std::regex_constants::icase);
+        sanitized = std::regex_replace(sanitized, trademark_re, "");
+        // Also trim extra spaces left after removal
+        // Simple trim leading and trailing spaces:
+        sanitized.erase(sanitized.begin(), std::find_if(sanitized.begin(), sanitized.end(), [](unsigned char ch)
+            {
+                return !std::isspace(ch);
+            }));
+        sanitized.erase(std::find_if(sanitized.rbegin(), sanitized.rend(), [](unsigned char ch)
+            {
+                return !std::isspace(ch);
+            }).base(), sanitized.end());
+
+        return sanitized;
+    }
+
     // Convert string to uppercase for case-insensitive matching
     std::string ToUpper(std::string str)
     {
@@ -243,15 +263,33 @@ namespace
     // 2) If no exact match, parse and estimate tier with suffix
     int GetTier(const std::string& upperName)
     {
+        // 1) Exact match first
         for (const auto& entry : gpuTable)
         {
-            if (upperName == entry.model)  // Exact match only!
+            if (upperName == entry.model)
             {
                 return entry.tier;
             }
         }
-        return ParseAndEstimate(upperName);
+
+        int estimatedTier = ParseAndEstimate(upperName);
+        if (estimatedTier > 0)
+        {
+            return estimatedTier;
+        }
+
+        for (const auto& entry : gpuTable)
+        {
+            if (upperName.find(entry.model) != std::string::npos)
+            {
+                return entry.tier;
+            }
+        }
+
+        // No match found
+        return 0;
     }
+
 
     // Compute minimum tier once, at startup, from MINIMUM_GPU_NAME
     const int kMinimumTier = []
@@ -271,20 +309,22 @@ namespace
 
 void CheckMinimumGPU(const std::string& gpuName)
 {
-    std::string upper = ToUpper(gpuName);
+    std::string sanitizedName = SanitizeGPUName(gpuName);
+
+    std::string upper = ToUpper(sanitizedName);
     std::string vendor = GetVendor(upper);
 
     int tier = GetTier(upper);
 
     if (tier == 0 && vendor == "INTEL")
     {
-        spdlog::warn("System Details - GPU: {} detected as Intel integrated graphics.", gpuName);
+        spdlog::warn("System Details - GPU: {} detected as Intel integrated graphics.", sanitizedName);
         tier = 20; // fallback for unrecognized Intel
     }
 
     if (tier == 0)
     {
-        spdlog::warn("System Details - GPU: {} ({}) was not recognized.", gpuName, vendor);
+        spdlog::warn("System Details - GPU: {} ({}) was not recognized.", sanitizedName, vendor);
         spdlog::warn("System Details - GPU: The game requires a minimum of a {} or equivalent.", MINIMUM_GPU_NAME);
         spdlog::warn("System Details - GPU: Degraded performance (ie \"Snake moving in slow motion\") and crashing likely to occur.");
         return;
@@ -292,7 +332,7 @@ void CheckMinimumGPU(const std::string& gpuName)
 
     if (tier < kMinimumTier)
     {
-        spdlog::info("System Details - GPU: {}", gpuName);
+        spdlog::info("System Details - GPU: {}", sanitizedName);
         spdlog::warn("System Details - GPU: This GPU is below the minimum system requirements of a {} or equivalent.", MINIMUM_GPU_NAME);
         int percent = tier * 100 / kMinimumTier;
         spdlog::warn("System Details - GPU: Estimated performance compared to a {}: {}%", MINIMUM_GPU_NAME, percent);
@@ -300,6 +340,6 @@ void CheckMinimumGPU(const std::string& gpuName)
     }
     else
     {
-        spdlog::info("System Details - GPU: {}", gpuName);
+        spdlog::info("System Details - GPU: {}", sanitizedName);
     }
 }

--- a/src/resources/gpu_check.cpp
+++ b/src/resources/gpu_check.cpp
@@ -20,20 +20,82 @@ namespace
 
     // GPU tier table without suffixes
     std::vector<GpuEntry> gpuTable = {
-        {"GTX 750 TI", 40}, {"GTX 950", 55}, {"GTX 960", 65}, {"GTX 970", 100},
-        {"GTX 980", 120}, {"GTX 980 TI", 140}, {"GTX 1050", 60}, {"GTX 1050 TI", 70},
-        {"GTX 1060 3GB", 110}, {"GTX 1060 6GB", 120}, {"GTX 1070", 150}, {"GTX 1080", 170},
+        // NVIDIA GPUs
+        {"GTX 650", 30}, {"GTX 650 TI", 35}, {"GTX 660", 50}, {"GTX 660 TI", 55},
+        {"GTX 670", 70}, {"GTX 680", 80}, {"GTX 690", 90},
+        {"GTX 750", 35}, {"GTX 750 TI", 40},
+        {"GTX 950", 55}, {"GTX 960", 65}, {"GTX 970", 100}, {"GTX 980", 120}, {"GTX 980 TI", 140},
+        {"GTX TITAN", 120}, {"GTX TITAN BLACK", 130}, {"GTX TITAN X", 150},
+        {"GTX 1050", 60}, {"GTX 1050 TI", 70},
+        {"GTX 1060 3GB", 110}, {"GTX 1060 6GB", 120}, {"GTX 1070", 150}, {"GTX 1070 TI", 160},
+        {"GTX 1080", 170}, {"GTX 1080 TI", 200},
         {"GTX 1650", 85}, {"GTX 1650 SUPER", 95}, {"GTX 1660", 125}, {"GTX 1660 TI", 135},
-        {"RTX 2060", 180}, {"RTX 2070", 200}, {"RTX 2080", 220}, {"RTX 3060", 200},
-        {"RTX 3070", 260}, {"RTX 3080", 300}, {"RTX 3090", 350}, {"RTX 4060", 220},
-        {"RTX 4070 TI", 310}, {"RTX 4070", 280}, {"RTX 4080", 350}, {"RTX 4090", 400},
-        {"R9 270X", 55}, {"R9 280", 70}, {"R9 290", 100}, {"R9 290X", 110},
-        {"RX 460", 50}, {"RX 470", 95}, {"RX 480", 100}, {"RX 570", 100},
-        {"RX 580", 110}, {"RX 590", 115}, {"RX 5500 XT", 120}, {"RX 5600 XT", 140},
-        {"RX 5700", 160}, {"RX 6600", 170}, {"RX 6700 XT", 220}, {"RX 6800", 270},
-        {"RX 6900 XT", 310}, {"RX 7600", 190}, {"RX 7700 XT", 230}, {"RX 7800 XT", 270},
+        {"RTX 2060", 180}, {"RTX 2060 SUPER", 190}, {"RTX 2070", 200}, {"RTX 2070 SUPER", 210},
+        {"RTX 2080", 220}, {"RTX 2080 SUPER", 230}, {"RTX 2080 TI", 250},
+        {"RTX 3060", 200}, {"RTX 3060 TI", 230}, {"RTX 3070", 260}, {"RTX 3070 TI", 280},
+        {"RTX 3080", 300}, {"RTX 3080 TI", 320}, {"RTX 3090", 350}, {"RTX 3090 TI", 370},
+        {"RTX 4060", 220}, {"RTX 4060 TI", 240}, {"RTX 4070", 280}, {"RTX 4070 TI", 310},
+        {"RTX 4080", 350}, {"RTX 4090", 400},
+
+        // AMD GPUs
+        {"R7 250", 30}, {"R7 250X", 35}, {"R7 260", 45}, {"R7 260X", 50},
+        {"R9 270", 50}, {"R9 270X", 55}, {"R9 280", 70}, {"R9 280X", 80},
+        {"R9 285", 85}, {"R9 290", 100}, {"R9 290X", 110}, {"R9 295X2", 130},
+        {"RX 460", 50}, {"RX 470", 95}, {"RX 480", 100}, {"RX 550", 40}, {"RX 560", 55},
+        {"RX 570", 100}, {"RX 580", 110}, {"RX 590", 115},
+        {"RX VEGA 56", 130}, {"RX VEGA 64", 150},
+        {"RX 5500 XT", 120}, {"RX 5600 XT", 140}, {"RX 5700", 160}, {"RX 5700 XT", 170},
+        {"RX 6500 XT", 100}, {"RX 6600", 170}, {"RX 6600 XT", 180},
+        {"RX 6700", 200}, {"RX 6700 XT", 220}, {"RX 6800", 270}, {"RX 6800 XT", 290},
+        {"RX 6900 XT", 310}, {"RX 6950 XT", 320},
+        {"RX 7600", 190}, {"RX 7600 XT", 200},
+        {"RX 7700 XT", 230}, {"RX 7800 XT", 270},
         {"RX 7900 XT", 340}, {"RX 7900 XTX", 360},
+
+        // Intel HD Graphics (Gen 6-8 iGPUs)
+        {"HD GRAPHICS", 3},
+        {"HD GRAPHICS 2000", 3},
+        {"HD GRAPHICS 2500", 4},
+        {"HD GRAPHICS 3000", 5},
+        {"HD GRAPHICS 4000", 10},
+        {"HD GRAPHICS 4200", 12},
+        {"HD GRAPHICS 4400", 13},
+        {"HD GRAPHICS 4600", 15},
+        {"HD GRAPHICS 5000", 18},
+        {"HD GRAPHICS 505", 19},
+        {"HD GRAPHICS 510", 20},
+        {"HD GRAPHICS 515", 20},
+        {"HD GRAPHICS 520", 22},
+        {"HD GRAPHICS 530", 24},
+        {"HD GRAPHICS 6000", 26},
+
+        // Intel UHD Graphics (Gen 9-12 iGPUs)
+        {"UHD GRAPHICS 600", 25},
+        {"UHD GRAPHICS 610", 28},
+        {"UHD GRAPHICS 615", 30},
+        {"UHD GRAPHICS 620", 32},
+        {"UHD GRAPHICS 630", 35},
+        {"UHD GRAPHICS 730", 38},
+        {"UHD GRAPHICS 750", 40},
+        {"UHD GRAPHICS 770", 45},
+
+        // Intel Iris / Iris Pro / Iris Plus
+        {"IRIS", 30},
+        {"IRIS PRO 5200", 32},
+        {"IRIS PRO 580", 40},
+        {"IRIS PLUS 540", 35},
+        {"IRIS PLUS 550", 38},
+        {"IRIS PLUS 655", 40},
+        {"IRIS XE", 60},
+
+        // Intel Arc GPUs
+        {"ARC A310", 90},
+        {"ARC A380", 120},
+        {"ARC A580", 170},
+        {"ARC A750", 210},
+        {"ARC A770", 230},
     };
+
 
     // Sort GPU table descending by model length for potential substring matching (not strictly necessary here)
     struct TableSorter
@@ -115,7 +177,7 @@ namespace
     int ParseAndEstimate(const std::string& name)
     {
         // Regex extracts: prefix (GTX/RTX/RX/etc), model number, optional suffix (TI/SUPER/ULTRA)
-        std::regex re(R"((GTX|RTX|RX|ARC|HD|IRIS)\s*([0-9]{3,4})(?:\s*(TI|SUPER|ULTRA))?)");
+        std::regex re(R"((GTX|RTX|RX|ARC|HD|IRIS|UHD|XE)\s*([0-9]{3,4})(?:\s*(TI|SUPER|ULTRA))?)");
         std::smatch match;
         if (std::regex_search(name, match, re))
         {
@@ -143,6 +205,15 @@ namespace
             else if (prefix == "HD")
             {
                 baseTier = 10;
+            }
+            else if (prefix == "UHD")
+            {
+                baseTier = 25;
+                if (modelNum >= 700) baseTier = 35;
+            }
+            else if (prefix == "XE")
+            {
+                baseTier = 60;
             }
 
             if (!suffix.empty())
@@ -204,6 +275,12 @@ void CheckMinimumGPU(const std::string& gpuName)
     std::string vendor = GetVendor(upper);
 
     int tier = GetTier(upper);
+
+    if (tier == 0 && vendor == "INTEL")
+    {
+        spdlog::warn("System Details - GPU: {} detected as Intel integrated graphics.", gpuName);
+        tier = 20; // fallback for unrecognized Intel
+    }
 
     if (tier == 0)
     {

--- a/src/resources/helper.cpp
+++ b/src/resources/helper.cpp
@@ -356,29 +356,6 @@ namespace Util
         return FALSE;
     }
 
-    bool stringToBool(const std::string& str)
-    {
-        std::string lowerStr = str;
-        std::transform(lowerStr.begin(), lowerStr.end(), lowerStr.begin(),
-            [](unsigned char c)
-            {
-                return std::tolower(c);
-            });
-        if (lowerStr == "true" || lowerStr == "1")
-        {
-            return true;
-        }
-        if (lowerStr == "false" || lowerStr == "0")
-        {
-            return false;
-        }
-        // Handle cases where the string is not a recognized boolean representation
-        // For example, throw an exception, return a default value, or log an error.
-        // For simplicity, this example returns false for unrecognized strings.
-        return false;
-    }
-
-
     std::string GetUppercaseNameAtIndex(const std::initializer_list<std::string>& list, int index)
     {
         if (index >= 0 && index < static_cast<int>(list.size()))

--- a/src/resources/helper.cpp
+++ b/src/resources/helper.cpp
@@ -1,13 +1,8 @@
-#include "helper.hpp"
+#include "common.hpp"
+
 #include "logging.hpp"
 
 #pragma comment(lib,"Version.lib")
-
-extern HMODULE baseModule;
-extern std::filesystem::path sExePath;
-extern std::filesystem::path sFixPath;
-extern std::string sExeName;
-
 
 namespace Memory
 {
@@ -114,7 +109,7 @@ namespace Memory
         std::uint8_t* foundPattern = PatternScanSilent(module, signature);
         if (foundPattern)
         {
-            if (bVerboseLogging)
+            if (g_Logging.bVerboseLogging)
             {
 
                 spdlog::info("{}: Pattern scan found. Address: {:s}+{:x}", prefix, sExeName.c_str(), (uintptr_t)foundPattern - (uintptr_t)baseModule);

--- a/src/resources/helper.cpp
+++ b/src/resources/helper.cpp
@@ -112,7 +112,7 @@ namespace Memory
             if (g_Logging.bVerboseLogging)
             {
 
-                spdlog::info("{}: Pattern scan found. Address: {:s}+{:x}", prefix, sExeName.c_str(), (uintptr_t)foundPattern - (uintptr_t)baseModule);
+                spdlog::info("{}: Pattern scan found. Address: {:s}+{:X}", prefix, sExeName.c_str(), (uintptr_t)foundPattern - (uintptr_t)baseModule);
             }
         }
         else

--- a/src/resources/helper.hpp
+++ b/src/resources/helper.hpp
@@ -49,8 +49,6 @@ namespace Util
 
     bool CheckForASIFiles(std::string fileName, bool checkForDuplicates, bool setFixPath, const char* checkCreationDate);
 
-    bool stringToBool(const std::string& str);
-
     std::string GetUppercaseNameAtIndex(const std::initializer_list<std::string>& list, int index);
 
     bool IsSteamOS();

--- a/src/resources/helper.hpp
+++ b/src/resources/helper.hpp
@@ -71,4 +71,81 @@ namespace Util
     {\
         spdlog::error("{}: Hook failed.", prefix);\
     }\
-}\
+}
+
+#define CONCAT_IMPL(x, y) x##y
+#define CONCAT(x, y) CONCAT_IMPL(x, y)
+#define UNIQUE_NAME(base) CONCAT(base, __COUNTER__)
+
+/**
+ * Usage:
+ * MAKE_HOOK_MID(module, pattern, name, {
+ *     // Your code here using ctx
+ * });
+ *
+ * Example:
+ * MAKE_HOOK_MID(baseModule, "74 ?? B9 ?? ?? ?? ??", "completion check", {
+ *     ctx.rax = 0;
+ *     reghelpers::SetZF(ctx, false);
+ * });
+ */
+#define MAKE_HOOK_MID_IMPL(module, pattern, name, body, uniq)                       \
+    if (uint8_t* CONCAT(_addr_, uniq) = Memory::PatternScan(module, pattern, name)) {\
+        static SafetyHookMid CONCAT(hook_, uniq) {};                               \
+        CONCAT(hook_, uniq) = safetyhook::create_mid(CONCAT(_addr_, uniq),         \
+            [](SafetyHookContext& ctx) { body });                                  \
+        LOG_HOOK(CONCAT(hook_, uniq), name)                                        \
+    }
+
+#define MAKE_HOOK_MID(module, pattern, name, body)                                 \
+    MAKE_HOOK_MID_IMPL(module, pattern, name, body, UNIQUE_NAME(_unique))
+
+ /**
+  * Usage:
+  * MAKE_HOOK_INLINE(module, pattern, name, {
+  *     // Your code here using ctx
+  * });
+  *
+  * Example:
+  * MAKE_HOOK_INLINE(baseModule, "83 F8 01 75 ?? 48 8B", "force always true", {
+  *     ctx.rax = 1;
+  * });
+  */
+
+#define MAKE_HOOK_INLINE_IMPL(module, pattern, name, body, uniq)                    \
+    if (uint8_t* CONCAT(_addr_, uniq) = Memory::PatternScan(module, pattern, name)) {\
+        static SafetyHookInline CONCAT(hook_, uniq) {};                            \
+        CONCAT(hook_, uniq) = safetyhook::create_inline(CONCAT(_addr_, uniq),      \
+            [](SafetyHookContext& ctx) { body });                                  \
+        LOG_HOOK(CONCAT(hook_, uniq), name)                                        \
+    }
+
+#define MAKE_HOOK_INLINE(module, pattern, name, body)                              \
+    MAKE_HOOK_INLINE_IMPL(module, pattern, name, body, UNIQUE_NAME(_unique))
+
+  /**
+   * Usage:
+   * MAKE_HOOK_TRAMPOLINE(module, pattern, name, ReturnType, {
+   *     // Your code here using ctx and trampoline
+   *     // Must return ReturnType
+   * });
+   *
+   * Example:
+   * MAKE_HOOK_TRAMPOLINE(baseModule, "E8 ?? ?? ?? ??", "feature toggle", bool, {
+   *     if (shouldEnableFeature())
+   *         return true;
+   *     return trampoline(ctx);
+   * });
+   */
+
+#define MAKE_HOOK_TRAMPOLINE_IMPL(module, pattern, name, retType, body, uniq)       \
+    if (uint8_t* CONCAT(_addr_, uniq) = Memory::PatternScan(module, pattern, name)) {\
+        static SafetyHookTrampoline<retType> CONCAT(hook_, uniq) {};               \
+        CONCAT(hook_, uniq) = safetyhook::create_trampoline<retType>(              \
+            CONCAT(_addr_, uniq), [](SafetyHookContext& ctx, auto& trampoline) {body});\
+        LOG_HOOK(CONCAT(hook_, uniq), name)                                        \
+    }
+
+#define MAKE_HOOK_TRAMPOLINE(module, pattern, name, retType, body)                 \
+    MAKE_HOOK_TRAMPOLINE_IMPL(module, pattern, name, retType, body, UNIQUE_NAME(_unique))
+

--- a/src/resources/helper.hpp
+++ b/src/resources/helper.hpp
@@ -3,8 +3,7 @@
 #include "stdafx.h"
 #include "RegStateHelpers.hpp"
 
-
-extern bool bVerboseLogging;
+inline std::filesystem::path sFixPath;
 
 namespace Memory
 {
@@ -39,7 +38,7 @@ namespace Memory
 
 namespace Util
 {
-    extern int findStringInVector(std::string& str, const std::initializer_list<std::string>& search);
+    int findStringInVector(std::string& str, const std::initializer_list<std::string>& search);
 
     // Convert an UTF8 string to a wide Unicode String
     std::wstring utf8_decode(const std::string& str);
@@ -63,7 +62,7 @@ namespace Util
 {\
     if (hook)\
     {\
-        if (bVerboseLogging)\
+        if (g_Logging.bVerboseLogging)\
         {\
             spdlog::info("{}: Hook installed.", prefix);\
         }\

--- a/src/resources/logging.cpp
+++ b/src/resources/logging.cpp
@@ -93,6 +93,7 @@ void Logging::Initialize()
             {
                 std::filesystem::create_directory(sExePath / "logs"); //create a "logs" subdirectory in the game folder to keep the main directory tidy.
             }
+            g_Logging.bLoaded = true;
             // Create 10MB truncated logger
             std::filesystem::path sLogFile = sFixName + ".log";
             std::shared_ptr<spdlog::logger> logger = std::make_shared<spdlog::logger>(sLogFile.string(), std::make_shared<size_limited_sink<std::mutex>>((sExePath / "logs" / sLogFile).string(), 10 * 1024 * 1024));
@@ -241,28 +242,43 @@ void Logging::LogSysInfo()
             }
         }
 
+        // Read UBR (Update Build Revision) value from registry
+        DWORD ubr = 0;
+        if (key != nullptr)
+        {
+            DWORD ubrSize = sizeof(ubr);
+            RegQueryValueExA(key, "UBR", nullptr, nullptr, reinterpret_cast<LPBYTE>(&ubr), &ubrSize);
+        }
+
         RegCloseKey(key);
 
         HMODULE ntdll = GetModuleHandleA("ntdll.dll");
-        while (ntdll)
+        if (ntdll)
         {
             typedef LONG(WINAPI* RtlGetVersion_t)(PRTL_OSVERSIONINFOW);
             RtlGetVersion_t RtlGetVersion =
                 reinterpret_cast<RtlGetVersion_t>(GetProcAddress(ntdll, "RtlGetVersion"));
-            if (!RtlGetVersion) break;
+            if (RtlGetVersion)
+            {
+                RTL_OSVERSIONINFOW info = {};
+                info.dwOSVersionInfoSize = sizeof(RTL_OSVERSIONINFOW);
 
-            RTL_OSVERSIONINFOW info = {};
-            info.dwOSVersionInfoSize = sizeof(RTL_OSVERSIONINFOW);
+                if (RtlGetVersion(&info) == 0)
+                {
+                    // Append build number and UBR (e.g. " (26100.4652)")
+                    os += " (" + std::to_string(info.dwBuildNumber) + "." + std::to_string(ubr) + ")";
 
-            if (RtlGetVersion(&info) != 0) break;
-            os += " (build " + std::to_string(info.dwBuildNumber) + ")";
-
-            if (info.dwBuildNumber < 22000) break;
-            std::size_t pos = os.find("Windows 10");
-
-            if (pos == std::string::npos) break;
-            os.replace(pos, 10, "Windows 11");
-            break;
+                    // Replace "Windows 10" with "Windows 11" if build number is 22000 or greater
+                    if (info.dwBuildNumber >= 22000)
+                    {
+                        std::size_t pos = os.find("Windows 10");
+                        if (pos != std::string::npos)
+                        {
+                            os.replace(pos, 10, "Windows 11");
+                        }
+                    }
+                }
+            }
         }
     }
     if (!os.empty()) spdlog::info("System Details - OS:  {}", os);

--- a/src/resources/logging.cpp
+++ b/src/resources/logging.cpp
@@ -116,6 +116,7 @@ void Logging::Initialize()
             spdlog::info("Module Name: {0:s}", sExeName.c_str());
             spdlog::info("Module Path: {0:s}", sExePath.string());
             spdlog::info("Module Address: 0x{0:x}", (uintptr_t)baseModule);
+            spdlog::info("Module First Instruction: 0x{0:x}", (uintptr_t)baseModule+0x1000);
             spdlog::info("Module Version: {}", Memory::GetModuleVersion(baseModule));
             if (std::filesystem::exists(sExePath / "steamclient64.dll") || std::filesystem::exists(sExePath / "steamclient.dll") || std::filesystem::exists(sExePath / "GameOverlayRenderer64.dll") || std::filesystem::exists(sExePath / "GameOverlayRenderer.dll"))
             {

--- a/src/resources/logging.cpp
+++ b/src/resources/logging.cpp
@@ -5,9 +5,7 @@
 
 #include "gpu_check.hpp"
 #include "steamworks_api.hpp"
-
-extern std::filesystem::path sFixPath;
-
+#include "version.h"
 
 
 // Spdlog sink (truncate on startup, single file)

--- a/src/resources/logging.cpp
+++ b/src/resources/logging.cpp
@@ -115,8 +115,8 @@ void Logging::Initialize()
             // Log module details
             spdlog::info("Module Name: {0:s}", sExeName.c_str());
             spdlog::info("Module Path: {0:s}", sExePath.string());
-            spdlog::info("Module Address: 0x{0:x}", (uintptr_t)baseModule);
-            spdlog::info("Module First Instruction: 0x{0:x}", (uintptr_t)baseModule+0x1000);
+            spdlog::info("Module Address: 0x{0:X}", (uintptr_t)baseModule);
+            spdlog::info("Module First Segment: 0x{0:X}", (uintptr_t)baseModule+0x1000);
             spdlog::info("Module Version: {}", Memory::GetModuleVersion(baseModule));
             if (std::filesystem::exists(sExePath / "steamclient64.dll") || std::filesystem::exists(sExePath / "steamclient.dll") || std::filesystem::exists(sExePath / "GameOverlayRenderer64.dll") || std::filesystem::exists(sExePath / "GameOverlayRenderer.dll"))
             {

--- a/src/resources/logging.hpp
+++ b/src/resources/logging.hpp
@@ -16,6 +16,7 @@ public:
     bool bLoaded = false;
     bool bIsSteamDeck = false;
     bool bCheckedSteamDeck = false;
+    bool bVerboseLogging = true;
 };
 
 /// Global logging instance

--- a/src/resources/logging.hpp
+++ b/src/resources/logging.hpp
@@ -13,6 +13,7 @@ public:
     static void LogSysInfo();
 
     std::chrono::time_point<std::chrono::high_resolution_clock> initStartTime;
+    bool bLoaded = false;
     bool bIsSteamDeck = false;
     bool bCheckedSteamDeck = false;
 };

--- a/src/resources/steamworks_api.cpp
+++ b/src/resources/steamworks_api.cpp
@@ -1,6 +1,5 @@
 #include "common.hpp"
 #include "steamworks_api.hpp"
-#include "stat_persistence.hpp"
 #include <logging.hpp>
 
 
@@ -11,6 +10,8 @@
 #include "isteaminput.h"
 
 #pragma warning(pop)
+
+void AfterSteamInitialized();
 
 namespace
 {
@@ -37,7 +38,7 @@ void SteamAPI::OnSteamInitialized()
     g_SteamAPI.bInitialized = true;
     ResetAllAchievements(); //DON'T FREAK OUT READING THIS. bResetAchievements needs to be true, and there's multiple user confirmations first.
                             //This must ALWAYS be called before StatPersistence to make sure we don't wipe out the user's persistence file if they cancel the reset.
-    g_StatPersistence.OnSteamInitialized();
+    AfterSteamInitialized();
 }
 
 

--- a/src/resources/steamworks_api.cpp
+++ b/src/resources/steamworks_api.cpp
@@ -8,12 +8,14 @@
 #pragma warning(disable:4828)
 #include <isteamuser.h>
 #include <isteamuserstats.h>
+#include "isteaminput.h"
 
 #pragma warning(pop)
 
 namespace
 {
     SafetyHookMid SteamMidhook;
+    SafetyHookMid SteamInputMidhook;
 
 }
 
@@ -23,7 +25,7 @@ void SteamAPI::FetchAndCacheSteamID()
     CSteamID mySteamID = SteamUser()->GetSteamID();
     if (!mySteamID.IsValid())
     {
-        spdlog::error("Steam Achievements - Failed to fetch SteamID. Is Steam running?");
+        spdlog::error("SteamAPI: Failed to fetch SteamID. Is Steam running?");
         return;
     }
     g_SteamAPI.steamID = mySteamID.ConvertToUint64();
@@ -32,7 +34,9 @@ void SteamAPI::FetchAndCacheSteamID()
 
 void SteamAPI::OnSteamInitialized()
 {
-    ResetAllAchievements(); //This must ALWAYS be called before StatPersistence to make sure we don't wipe out the user's persistence file if they cancel the reset.
+    g_SteamAPI.bInitialized = true;
+    ResetAllAchievements(); //DON'T FREAK OUT READING THIS. bResetAchievements needs to be true, and there's multiple user confirmations first.
+                            //This must ALWAYS be called before StatPersistence to make sure we don't wipe out the user's persistence file if they cancel the reset.
     g_StatPersistence.OnSteamInitialized();
 }
 
@@ -179,7 +183,7 @@ void SteamAPI::Setup() const
 {
     if (!bIsLegitCopy)
     {
-        spdlog::warn("Steam Achievements: Steam achievement/stat tracking fixes are disabled due to non-legitimate copy.");
+        spdlog::warn("SteamAPI: Steam achievement/stat tracking fixes are disabled due to non-legitimate copy.");
         return;
     }
 
@@ -197,4 +201,50 @@ void SteamAPI::Setup() const
             });
         LOG_HOOK(SteamMidhook, "SteamAPI Initialization")
     }
+
+}
+
+void SteamAPI::LogControllers()
+{
+    if (!g_SteamAPI.bInitialized)
+    {
+        return;
+    }
+    ISteamInput* steamInput = SteamInput();
+    InputHandle_t handles[STEAM_INPUT_MAX_COUNT] = {};
+    steamInput->RunFrame();
+    int count = steamInput->GetConnectedControllers(handles);
+
+    spdlog::info("SteamInput: Detected {} controller{}.", count, count == 1 ? "" : "s");
+
+    for (int i = 0; i < count; ++i)
+    {
+        InputHandle_t handle = handles[i];
+        ESteamInputType type = steamInput->GetInputTypeForHandle(handle);
+        int gamepadIndex = steamInput->GetGamepadIndexForController(handle);
+
+        const char* typeStr = "Unknown";
+        switch (type)
+        {
+        case k_ESteamInputType_SteamController: typeStr = "Steam Controller"; break;
+        case k_ESteamInputType_XBox360Controller: typeStr = "Xbox 360"; break;
+        case k_ESteamInputType_XBoxOneController: typeStr = "Xbox One"; break;
+        case k_ESteamInputType_PS4Controller: typeStr = "PS4"; break;
+        case k_ESteamInputType_PS5Controller: typeStr = "PS5"; break;
+        case k_ESteamInputType_SwitchProController: typeStr = "Switch Pro"; break;
+        case k_ESteamInputType_GenericGamepad: typeStr = "Generic Gamepad"; break;
+        case k_ESteamInputType_AppleMFiController: typeStr = "Apple MFi"; break;
+        case k_ESteamInputType_AndroidController: typeStr = "Android Controller"; break;
+        case k_ESteamInputType_SwitchJoyConPair: typeStr = "Switch Joy-Con Pair"; break;
+        case k_ESteamInputType_SwitchJoyConSingle: typeStr = "Switch Joy-Con Single"; break;
+        case k_ESteamInputType_MobileTouch: typeStr = "Mobile Touch"; break;
+        case k_ESteamInputType_PS3Controller: typeStr = "PS3"; break;
+        case k_ESteamInputType_SteamDeckController: typeStr = "Steam Deck"; break;
+        default: break;
+        }
+
+        spdlog::info("SteamInput: Controller #{} | Type: {} | Handle: {} | Input Handler: {}", i+1, typeStr, handle, gamepadIndex == -1 ? "Steam Input" : std::to_string(gamepadIndex));
+
+    }
+
 }

--- a/src/resources/steamworks_api.hpp
+++ b/src/resources/steamworks_api.hpp
@@ -10,10 +10,12 @@ private:
     static void OnSteamInitialized();
     static void FetchAndCacheSteamID();
     static void ResetAllAchievements();
+    bool bInitialized = false;
 
 public:
     void Setup() const;
 
+    static void LogControllers();
 
     // Achievement-related wrappers
     [[nodiscard]] static bool SetAchievement(const char* achievementID);

--- a/src/resources/version.h
+++ b/src/resources/version.h
@@ -1,23 +1,23 @@
 ﻿#pragma once
+// ReSharper disable CppClangTidyModernizeMacroToEnum
 
 // Core name & version
 #define FIX_NAME "MGSHDFix"
-#define VERSION_STRING "2.5.1"
 #define PRIMARY_REPO_URL "https://github.com/Lyall/MGSHDFix"
 //#define FALLBACK_REPO_URL "https://codeberg.org/Lyall/MGSHDFix"
 
+#define VERSION_MAJOR 2
+#define VERSION_MINOR 5
+#define VERSION_PATCH 1
 
-// Version
-inline constexpr std::string sFixVersion = VERSION_STRING;
-inline constexpr std::string sFixName = FIX_NAME;
 inline constexpr int iConfigVersion = 4; //increment this when making config changes, along with the number at the bottom of the config file
 //that way we can sanity check to ensure people don't have broken/disabled features due to old config files.
 
-
-
-#define VERSION_MAJOR     2
-#define VERSION_MINOR     5
-#define VERSION_PATCH     1
+#define STRINGIFY_HELPER(x) #x
+#define STRINGIFY(x) STRINGIFY_HELPER(x)
+#define VERSION_STRING STRINGIFY(VERSION_MAJOR) "." STRINGIFY(VERSION_MINOR) "." STRINGIFY(VERSION_PATCH)
+inline constexpr std::string sFixVersion = VERSION_STRING;
+inline constexpr std::string sFixName = FIX_NAME;
 
 // Metadata
 #define COMPANY_NAME      "Lyall & Contributors"

--- a/src/resources/version.h
+++ b/src/resources/version.h
@@ -4,7 +4,7 @@
 // Core name & version
 #define FIX_NAME "MGSHDFix"
 #define PRIMARY_REPO_URL "https://github.com/Lyall/MGSHDFix"
-//#define FALLBACK_REPO_URL "https://codeberg.org/Lyall/MGSHDFix"
+#define FALLBACK_REPO_URL "https://github.com/ShizCalev/MGSHDFix"
 
 #define VERSION_MAJOR 2
 #define VERSION_MINOR 5

--- a/src/resources/version.h
+++ b/src/resources/version.h
@@ -8,10 +8,8 @@
 
 #define VERSION_MAJOR 2
 #define VERSION_MINOR 5
-#define VERSION_PATCH 1
+#define VERSION_PATCH 2
 
-inline constexpr int iConfigVersion = 4; //increment this when making config changes, along with the number at the bottom of the config file
-//that way we can sanity check to ensure people don't have broken/disabled features due to old config files.
 
 #define STRINGIFY_HELPER(x) #x
 #define STRINGIFY(x) STRINGIFY_HELPER(x)

--- a/src/resources/version.h
+++ b/src/resources/version.h
@@ -6,6 +6,15 @@
 #define PRIMARY_REPO_URL "https://github.com/Lyall/MGSHDFix"
 //#define FALLBACK_REPO_URL "https://codeberg.org/Lyall/MGSHDFix"
 
+
+// Version
+inline constexpr std::string sFixVersion = VERSION_STRING;
+inline constexpr std::string sFixName = FIX_NAME;
+inline constexpr int iConfigVersion = 4; //increment this when making config changes, along with the number at the bottom of the config file
+//that way we can sanity check to ensure people don't have broken/disabled features due to old config files.
+
+
+
 #define VERSION_MAJOR     2
 #define VERSION_MINOR     5
 #define VERSION_PATCH     1

--- a/src/resources/version.h
+++ b/src/resources/version.h
@@ -1,15 +1,10 @@
 ﻿#pragma once
 
 // Core name & version
-#define FIX_NAME          "MGSHDFix"
-#define VERSION_STRING    "2.5.1"
-#define REPO_OWNER       "Lyall" //Owner of the repository to check for updates, ie github.com/ -> Lyall <- this part
-#define REPO_NAME         "MGSHDFix" //Name of the repository to check for updates, ie github.com/Lyall/ -> MGSHDFix <- this part
-/// Defines the repository API to use for version checking
-#define REPO_GITHUB
-//#define REPO_CODEBERG
-//#define REPO_GITLAB
-
+#define FIX_NAME "MGSHDFix"
+#define VERSION_STRING "2.5.1"
+#define PRIMARY_REPO_URL "https://github.com/Lyall/MGSHDFix"
+//#define FALLBACK_REPO_URL "https://codeberg.org/Lyall/MGSHDFix"
 
 #define VERSION_MAJOR     2
 #define VERSION_MINOR     5

--- a/src/resources/version_checking.cpp
+++ b/src/resources/version_checking.cpp
@@ -1,66 +1,77 @@
-#include "common.hpp"
 #include "version_checking.hpp"
+#include "logging.hpp"
 
-#include <windows.h>
-#include <winhttp.h>
+LatestVersionChecker::LatestVersionChecker(const std::filesystem::path& cacheFile)
+    : m_cacheFile(cacheFile)
+{
+}
+
+#if !defined(PRIMARY_REPO_URL) && !defined(FALLBACK_REPO_URL)
+
+
+bool LatestVersionChecker::checkForUpdates()
+{
+    spdlog::error("Update Checker called but no repository URLs are defined (PRIMARY_REPO_URL and FALLBACK_REPO_URL missing).");
+    throw std::invalid_argument("Update Checker called but no repository URLs are defined (PRIMARY_REPO_URL and FALLBACK_REPO_URL missing).");
+}
+
+#else // At least one repo URL is defined
 
 #include <iostream>
 #include <fstream>
 #include <regex>
 #include <iomanip>
 #include <sstream>
-
-#include "logging.hpp"
-#include "version.h"
-
-#if (defined(REPO_GITHUB) + defined(REPO_CODEBERG) + defined(REPO_GITLAB)) > 1
-#error "Only one of REPO_GITHUB, REPO_CODEBERG, or REPO_GITLAB may be defined at a time."
-#elif !(defined(REPO_GITHUB) || defined(REPO_CODEBERG) || defined(REPO_GITLAB))
-#error "You must define one of REPO_GITHUB, REPO_CODEBERG, or REPO_GITLAB."
-#endif
+#include <windows.h>
+#include <winhttp.h>
 
 #pragma comment(lib, "winhttp.lib")
 
 extern bool bConsoleNotifications;
 
-LatestVersionChecker::LatestVersionChecker(const std::string& dllVersion,
-    const std::string& repoOwner,
-    const std::string& repoName,
-    const std::filesystem::path& cacheFile,
-    int cacheTTLHours)
-    : m_dllVersion(dllVersion),
-    m_repoOwner(repoOwner),
-    m_repoName(repoName),
-    m_cacheFile(cacheFile),
-    m_cacheTTLHours(cacheTTLHours)
+inline std::string to_lower(std::string str)
 {
+    std::ranges::transform(str, str.begin(),
+        [](unsigned char c)
+        {
+            return std::tolower(c);
+        });
+    return str;
 }
 
 bool LatestVersionChecker::checkForUpdates()
 {
-    // Determine proper-cased apiHostStr for logging
-    const std::string apiHostStr =
-#ifdef REPO_GITHUB
-        "GitHub.com";
-#elif defined(REPO_CODEBERG)
-        "Codeberg.org";
-#elif defined(REPO_GITLAB)
-        "GitLab.com";
-#else
-#error "No repository API defined (REPO_GITHUB / REPO_CODEBERG / REPO_GITLAB)"
-#endif
-
-        std::string cachedLatest, warnedVersion;
+    std::string cachedLatest, warnedVersion;
     bool cacheIsFresh = false;
+
+    bool didCheck = false;
 
     if (!loadCache(cachedLatest, warnedVersion, cacheIsFresh))
     {
-        // No cache at all -> query API
-        spdlog::info("Version Check: No cache found. Contacting {} API for latest version.", apiHostStr);
+#if defined(PRIMARY_REPO_URL)
+        RepoInfo repoInfo = parseRepoUrl(PRIMARY_REPO_URL);
+        spdlog::info("Version Check: No cache found. Contacting {} API for latest version.", repoInfo.displayName);
 
-        if (!queryGitHubLatestVersion(cachedLatest))
+        if (queryLatestVersion(repoInfo, cachedLatest))
         {
-            spdlog::info("Version Check: Unable to contact {} API. Skipping version check.", apiHostStr);
+            didCheck = true;
+        }
+        else
+#endif
+#if defined(FALLBACK_REPO_URL)
+        {
+            RepoInfo repoInfo = parseRepoUrl(FALLBACK_REPO_URL);
+            spdlog::info("Version Check: Primary API failed or missing. Trying fallback {}.", repoInfo.displayName);
+
+            if (queryLatestVersion(repoInfo, cachedLatest))
+            {
+                didCheck = true;
+            }
+        }
+#endif
+        if (!didCheck)
+        {
+            spdlog::info("Version Check: Unable to contact Repo API. Skipping version check.");
             return false;
         }
 
@@ -68,33 +79,61 @@ bool LatestVersionChecker::checkForUpdates()
     }
     else if (!cacheIsFresh)
     {
-        spdlog::info("Version Check: Cache stale. Refreshing from {} API.", apiHostStr);
+#if defined(PRIMARY_REPO_URL)
+        RepoInfo primaryRepoInfo = parseRepoUrl(PRIMARY_REPO_URL);
+        spdlog::info("Version Check: Cache stale. Refreshing from {} API.", primaryRepoInfo.displayName);
+
         std::string latestFromApi;
-        if (queryGitHubLatestVersion(latestFromApi))
+        if (queryLatestVersion(primaryRepoInfo, latestFromApi))
         {
             cachedLatest = latestFromApi;
             saveCache(cachedLatest, warnedVersion);
+            didCheck = true;
+        }
+#endif
+
+#if defined(FALLBACK_REPO_URL)
+        // If primary didn't check or failed, try fallback
+        if (!didCheck)
+        {
+            RepoInfo fallbackRepoInfo = parseRepoUrl(FALLBACK_REPO_URL);
+            spdlog::info("Version Check: Primary API failed or missing on stale cache. Trying fallback {}.", fallbackRepoInfo.displayName);
+
+            std::string latestFromFallback;
+            if (queryLatestVersion(fallbackRepoInfo, latestFromFallback))
+            {
+                cachedLatest = latestFromFallback;
+                saveCache(cachedLatest, warnedVersion);
+                didCheck = true;
+            }
+        }
+#endif
+
+        if (!didCheck)
+        {
+            spdlog::info("Version Check: Unable to contact Repo API on stale cache. Skipping version check.");
+            return false;
         }
     }
     else
     {
-        spdlog::info("Version Check: Under {} hours since last update check. Skipping {} API call.", m_cacheTTLHours, apiHostStr);
+        spdlog::info("Version Check: Under {} hours since last update check. Skipping update check.", iCacheTTLHours);
     }
 
-    int cmp = compareSemVer(m_dllVersion, cachedLatest);
+    int cmp = compareSemVer(VERSION_STRING, cachedLatest);
 
     if (cmp < 0)
     {
-        spdlog::warn("Version Check: A new version of {} is available from {}.", sFixName, apiHostStr);
-        spdlog::warn("Version Check - Current Version: {}, Latest Release: {}", m_dllVersion, cachedLatest);
+        spdlog::warn("Version Check: A new version of {} is available.", FIX_NAME);
+        spdlog::warn("Version Check - Current Version: {}, Latest Version: {}", VERSION_STRING, cachedLatest);
 
         if (warnedVersion != cachedLatest)
         {
             if (bConsoleNotifications)
             {
                 Logging::ShowConsole();
-                std::cout << sFixName << " Update Notice: A new version of " << sFixName << " is available for download.\nCurrent Version: "
-                    << m_dllVersion << ", Latest Version: " << cachedLatest << std::endl;
+                std::cout << FIX_NAME << " Update Notice: New version of " << FIX_NAME << " is available.\nCurrent Version: "
+                    << VERSION_STRING << ", Latest Version: " << cachedLatest << std::endl;
             }
             saveCache(cachedLatest, cachedLatest);
             return true;
@@ -103,13 +142,12 @@ bool LatestVersionChecker::checkForUpdates()
     }
     else if (cmp > 0)
     {
-        spdlog::info("Version Check: Welcome back, Commander! You're running a development build of {}!", sFixName);
-        spdlog::info("Version Check - Current Version: {}, Latest Release: {}", m_dllVersion, cachedLatest);
+        spdlog::info("Version Check: Welcome back, Commander! You're running a development build of {}!", FIX_NAME);
+        spdlog::info("Version Check - Current Version: {}, Latest Release: {}", VERSION_STRING, cachedLatest);
         return false;
     }
 
-    spdlog::info("Version Check: {} is up to date ({}).", sFixName, apiHostStr);
-    spdlog::info("Version Check - Current Version: {}", m_dllVersion);
+    spdlog::info("Version Check: {} is up to date.", FIX_NAME);
     return false;
 }
 
@@ -124,12 +162,12 @@ bool LatestVersionChecker::loadCache(std::string& cachedLatest, std::string& war
 
     cachedLatest = versionLine;
 
-    std::getline(file, warnedVersion);  // may be empty
+    std::getline(file, warnedVersion);
 
     auto cachedTime = parseISO8601(timeLine);
     auto now = std::chrono::system_clock::now();
     auto age = std::chrono::duration_cast<std::chrono::hours>(now - cachedTime);
-    cacheIsFresh = (age.count() <= m_cacheTTLHours);
+    cacheIsFresh = (age.count() <= iCacheTTLHours);
 
     return true;
 }
@@ -146,39 +184,62 @@ void LatestVersionChecker::saveCache(const std::string& latestVersion, const std
 
 std::wstring LatestVersionChecker::buildUserAgent() const
 {
-    std::string ua = sFixName + "/";
-    ua += VERSION_STRING;
+    std::string ua = std::string(FIX_NAME) + "/" + VERSION_STRING;
     return std::wstring(ua.begin(), ua.end());
 }
 
-bool LatestVersionChecker::queryGitHubLatestVersion(std::string& latestVersion)
+LatestVersionChecker::RepoInfo LatestVersionChecker::parseRepoUrl(const std::string& url) const
 {
-    // Determine lowercase apiHost for HTTP calls
-    const std::wstring apiHost =
-#ifdef REPO_GITHUB
-        L"api.github.com";
-#elif defined(REPO_CODEBERG)
-        L"codeberg.org";
-#elif defined(REPO_GITLAB)
-        L"gitlab.com";
-#else
-#error "No repository API defined (REPO_GITHUB / REPO_CODEBERG / REPO_GITLAB)"
-#endif
+    std::regex re(R"(https://([^/]+)/([^/]+)/([^/]+))");
+    std::smatch m;
 
-        // Compose path according to repo
-        std::wstring path;
-#ifdef REPO_GITHUB
-    path = L"/repos/" + std::wstring(m_repoOwner.begin(), m_repoOwner.end()) + L"/" +
-        std::wstring(m_repoName.begin(), m_repoName.end()) + L"/releases/latest";
-#elif defined(REPO_CODEBERG)
-    path = L"/api/v1/repos/" + std::wstring(m_repoOwner.begin(), m_repoOwner.end()) + L"/" +
-        std::wstring(m_repoName.begin(), m_repoName.end()) + L"/releases/latest";
-#elif defined(REPO_GITLAB)
-    path = L"/api/v4/projects/" + std::wstring(m_repoOwner.begin(), m_repoOwner.end()) + L"%2F" +
-        std::wstring(m_repoName.begin(), m_repoName.end()) + L"/releases";
-#endif
+    if (!std::regex_match(url, m, re))
+    {
+        spdlog::error("Version Check: Invalid repository URL format: {}", url);
+        throw std::invalid_argument("Invalid repository URL: " + url);
+    }
 
-    spdlog::info("Version Check: Contacting {} API for latest version...", std::string(apiHost.begin(), apiHost.end()));
+
+    std::string host = m[1];
+    std::string owner = m[2];
+    std::string repo = m[3];
+
+    RepoInfo info;
+
+    if (host == "github.com")
+    {
+        info.displayName = "GitHub.com";
+        info.apiHost = L"api.github.com";
+        info.apiPath = L"/repos/" + std::wstring(owner.begin(), owner.end()) +
+            L"/" + std::wstring(repo.begin(), repo.end()) + L"/releases/latest";
+    }
+    else if (host == "codeberg.org")
+    {
+        info.displayName = "Codeberg.org";
+        info.apiHost = L"codeberg.org";
+        info.apiPath = L"/api/v1/repos/" + std::wstring(owner.begin(), owner.end()) +
+            L"/" + std::wstring(repo.begin(), repo.end()) + L"/releases/latest";
+    }
+    else if (host == "gitlab.com")
+    {
+        info.displayName = "GitLab.com";
+        info.apiHost = L"gitlab.com";
+        info.apiPath = L"/api/v4/projects/" +
+            std::wstring(owner.begin(), owner.end()) + L"%2F" +
+            std::wstring(repo.begin(), repo.end()) + L"/releases";
+    }
+    else
+    {
+        spdlog::error("Version Check: Unsupported host: {}", host);
+        throw std::invalid_argument("Unsupported host: " + host);
+    }
+
+    return info;
+}
+
+bool LatestVersionChecker::queryLatestVersion(const RepoInfo& repoInfo, std::string& latestVersion)
+{
+    spdlog::info("Version Check: Contacting {} API...", repoInfo.displayName);
 
     HINTERNET hSession = WinHttpOpen(
         buildUserAgent().c_str(),
@@ -189,18 +250,19 @@ bool LatestVersionChecker::queryGitHubLatestVersion(std::string& latestVersion)
 
     if (!hSession)
     {
-        spdlog::error("WinHttpOpen failed.");
+        spdlog::error("Version Check: WinHttpOpen failed with error: {}", GetLastError());
         return false;
     }
 
     HINTERNET hConnect = WinHttpConnect(
         hSession,
-        apiHost.c_str(),
+        repoInfo.apiHost.c_str(),
         INTERNET_DEFAULT_HTTPS_PORT,
         0);
 
     if (!hConnect)
     {
+        spdlog::error("Version Check: WinHttpConnect failed with error: {}", GetLastError());
         WinHttpCloseHandle(hSession);
         return false;
     }
@@ -208,7 +270,7 @@ bool LatestVersionChecker::queryGitHubLatestVersion(std::string& latestVersion)
     HINTERNET hRequest = WinHttpOpenRequest(
         hConnect,
         L"GET",
-        path.c_str(),
+        repoInfo.apiPath.c_str(),
         nullptr,
         WINHTTP_NO_REFERER,
         WINHTTP_DEFAULT_ACCEPT_TYPES,
@@ -216,17 +278,21 @@ bool LatestVersionChecker::queryGitHubLatestVersion(std::string& latestVersion)
 
     if (!hRequest)
     {
+        spdlog::error("Version Check: WinHttpOpenRequest failed with error: {}", GetLastError());
         WinHttpCloseHandle(hConnect);
         WinHttpCloseHandle(hSession);
         return false;
     }
 
     std::wstring userAgentHeader = L"User-Agent: " + buildUserAgent();
-    WinHttpAddRequestHeaders(
-        hRequest,
-        userAgentHeader.c_str(),
-        -1,
-        WINHTTP_ADDREQ_FLAG_REPLACE);
+    if (!WinHttpAddRequestHeaders(hRequest, userAgentHeader.c_str(), (DWORD)-1, WINHTTP_ADDREQ_FLAG_ADD))
+    {
+        spdlog::error("Version Check: WinHttpAddRequestHeaders failed with error: {}", GetLastError());
+        WinHttpCloseHandle(hRequest);
+        WinHttpCloseHandle(hConnect);
+        WinHttpCloseHandle(hSession);
+        return false;
+    }
 
     std::string response;
 
@@ -244,6 +310,10 @@ bool LatestVersionChecker::queryGitHubLatestVersion(std::string& latestVersion)
             WinHttpReadData(hRequest, &buffer[0], size, &downloaded);
             response.append(buffer, 0, downloaded);
         } while (size > 0);
+    }
+    else
+    {
+        spdlog::error("Version Check: WinHttpSendRequest or WinHttpReceiveResponse failed with error: {}", GetLastError());
     }
 
     WinHttpCloseHandle(hRequest);
@@ -265,7 +335,6 @@ int LatestVersionChecker::compareSemVer(const std::string& a, const std::string&
 {
     std::istringstream sa(a), sb(b);
     int va[3] = { 0 }, vb[3] = { 0 };
-
     char dot;
     sa >> va[0] >> dot >> va[1] >> dot >> va[2];
     sb >> vb[0] >> dot >> vb[1] >> dot >> vb[2];
@@ -294,3 +363,5 @@ std::chrono::system_clock::time_point LatestVersionChecker::parseISO8601(const s
     ss >> std::get_time(&tm, "%Y-%m-%dT%H:%M:%S");
     return std::chrono::system_clock::from_time_t(std::mktime(&tm));
 }
+
+#endif // Repo URL defined check

--- a/src/resources/version_checking.cpp
+++ b/src/resources/version_checking.cpp
@@ -1,5 +1,19 @@
+#include "common.hpp"
 #include "version_checking.hpp"
+
 #include "logging.hpp"
+
+void CheckForUpdates()
+{
+    if (!bShouldCheckForUpdates)
+    {
+        spdlog::info("Mod update checking disabled via config.");
+        return;
+    }
+    std::filesystem::path cacheFilePath = sGameSavePath / (sFixName + "_version_check.txt");
+    LatestVersionChecker checker(cacheFilePath);
+    checker.checkForUpdates();
+}
 
 LatestVersionChecker::LatestVersionChecker(const std::filesystem::path& cacheFile)
     : m_cacheFile(cacheFile)
@@ -26,8 +40,6 @@ bool LatestVersionChecker::checkForUpdates()
 #include <winhttp.h>
 
 #pragma comment(lib, "winhttp.lib")
-
-extern bool bConsoleNotifications;
 
 inline std::string to_lower(std::string str)
 {
@@ -129,7 +141,7 @@ bool LatestVersionChecker::checkForUpdates()
 
         if (warnedVersion != cachedLatest)
         {
-            if (bConsoleNotifications)
+            if (bConsoleUpdateNotifications)
             {
                 Logging::ShowConsole();
                 std::cout << FIX_NAME << " Update Notice: New version of " << FIX_NAME << " is available.\nCurrent Version: "

--- a/src/resources/version_checking.hpp
+++ b/src/resources/version_checking.hpp
@@ -37,3 +37,8 @@ private:
 
 #endif
 };
+
+inline bool bShouldCheckForUpdates;
+inline bool bConsoleUpdateNotifications;
+
+void CheckForUpdates();

--- a/src/resources/version_checking.hpp
+++ b/src/resources/version_checking.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "version.h"
 
 #include <string>
 #include <chrono>
@@ -7,30 +8,32 @@
 class LatestVersionChecker
 {
 public:
-    explicit LatestVersionChecker(
-        const std::string& dllVersion,
-        const std::string& repoOwner,
-        const std::string& repoName,
-        const std::filesystem::path& cacheFile = "version_cache.txt",
-        int cacheTTLHours = 24);
+    explicit LatestVersionChecker(const std::filesystem::path& cacheFile = "version_cache.txt");
 
-    /// Runs the version check. Returns true if the user should see the outdated warning popup.
     bool checkForUpdates();
 
 private:
-    std::string m_dllVersion;
-    std::string m_repoOwner;
-    std::string m_repoName;
     std::filesystem::path m_cacheFile;
-    int m_cacheTTLHours;
+
+#if defined(PRIMARY_REPO_URL) || defined(FALLBACK_REPO_URL)
+
+    struct RepoInfo
+    {
+        std::wstring apiHost;
+        std::wstring apiPath;
+        std::string displayName;
+    };
 
     bool loadCache(std::string& cachedLatest, std::string& warnedVersion, bool& cacheIsFresh);
     void saveCache(const std::string& latestVersion, const std::string& warnedVersion);
-    bool queryGitHubLatestVersion(std::string& latestVersion);
-
+    bool queryLatestVersion(const RepoInfo& repoInfo, std::string& latestVersion);
     std::wstring buildUserAgent() const;
+    RepoInfo parseRepoUrl(const std::string& url) const;
 
     static int compareSemVer(const std::string& a, const std::string& b);
     static std::string currentTimeISO8601();
     static std::chrono::system_clock::time_point parseISO8601(const std::string& timeStr);
+    static constexpr int iCacheTTLHours = 24; // Cache TTL in hours
+
+#endif
 };

--- a/src/warnings/mute_warning.cpp
+++ b/src/warnings/mute_warning.cpp
@@ -43,7 +43,7 @@ void MuteWarning::Setup()
         }
         if (g_Logging.bVerboseLogging)
         {
-            spdlog::info("MG-MG2 | MGS 2 | MGS3: Mute Warning: Settings strut is at {:s}+{:x}", sExeName.c_str(), reinterpret_cast<uintptr_t>(muteWarningAddress) - reinterpret_cast<uintptr_t>(baseModule));
+            spdlog::info("MG-MG2 | MGS 2 | MGS3: Mute Warning: Settings strut is at {:s}+{:X}", sExeName.c_str(), reinterpret_cast<uintptr_t>(muteWarningAddress) - reinterpret_cast<uintptr_t>(baseModule));
         }
     }
 

--- a/src/warnings/mute_warning.cpp
+++ b/src/warnings/mute_warning.cpp
@@ -41,7 +41,7 @@ void MuteWarning::Setup()
             spdlog::error("MG-MG2 | MGS 2 | MGS3: Mute Warning: Settings strut not found.");
             return;
         }
-        if (bVerboseLogging)
+        if (g_Logging.bVerboseLogging)
         {
             spdlog::info("MG-MG2 | MGS 2 | MGS3: Mute Warning: Settings strut is at {:s}+{:x}", sExeName.c_str(), reinterpret_cast<uintptr_t>(muteWarningAddress) - reinterpret_cast<uintptr_t>(baseModule));
         }

--- a/src/warnings/reshade_compatibility_checks.cpp
+++ b/src/warnings/reshade_compatibility_checks.cpp
@@ -1,5 +1,7 @@
 #include "common.hpp"
 #include "reshade_compatibility_checks.hpp"
+
+#include "config.hpp"
 #include "logging.hpp"
 
 void ReshadeCompatibility::Check()

--- a/src/warnings/reshade_compatibility_checks.hpp
+++ b/src/warnings/reshade_compatibility_checks.hpp
@@ -5,3 +5,5 @@ class ReshadeCompatibility final
 public:
     static void Check();
 };
+
+inline bool bOutdatedReshade;


### PR DESCRIPTION
Test change for supporting GTX 1650's, which while they're technically under the game's minimum system requirements, don't normally crash in an unmodded environment. 

I suspect this might be due to the compiled vector shader blob expiring for them somehow, but I'll need someone who actually has a 1650 to test these changes. 

(Steamdeck untested. don't merge this just yet.)