### PR TITLE
Further CPU usage reduction

### DIFF
--- a/MGSHDFix.vcxproj
+++ b/MGSHDFix.vcxproj
@@ -212,7 +212,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v145</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/MGSHDFix.vcxproj
+++ b/MGSHDFix.vcxproj
@@ -212,7 +212,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v145</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/src/fixes/busy_loop_fix.cpp
+++ b/src/fixes/busy_loop_fix.cpp
@@ -30,9 +30,7 @@ __int64 BusyLoopFix::ActorWait_Hook()
 
     if (result == 0)
     {
-        double elapsed = GetElapsedTime();
-        double target = g_GameVars.ActorWaitValue();
-        double remaining = target - elapsed;
+        double remaining = g_GameVars.ActorWaitValue() - GetElapsedTime();
 
         // sleep may not be fully accurate, even with timeBeginPeriod.
         // a 3ms buffer should be more than enough to avoid overshooting our 

--- a/src/fixes/busy_loop_fix.cpp
+++ b/src/fixes/busy_loop_fix.cpp
@@ -2,12 +2,15 @@
 #include "common.hpp"
 #include "busy_loop_fix.hpp"
 #include "logging.hpp"
+#include "helper.hpp"
 
 static BusyLoopFix* g_instance = nullptr;
+typedef double GetElapsedTime_t();
+GetElapsedTime_t* GetElapsedTime;
 
 BOOL WINAPI BusyLoopFix::PeekMessageW_Hook(LPMSG m, HWND h, UINT a, UINT b, UINT c)
 {
-    BOOL r = g_instance->m_hook.call<BOOL>(m, h, a, b, c);
+    BOOL r = g_instance->m_peekMessageHook.call<BOOL>(m, h, a, b, c);
 
     if (!r)
     {
@@ -17,14 +20,28 @@ BOOL WINAPI BusyLoopFix::PeekMessageW_Hook(LPMSG m, HWND h, UINT a, UINT b, UINT
     return r;
 }
 
+__int64 BusyLoopFix::ActorWait_Hook()
+{
+    __int64 result = g_instance->m_actorWaitHook.call<__int64>();
+
+    if (result == 0)
+    {
+        double elapsed = GetElapsedTime();
+        double target = g_instance->m_actorWaitValue ? *g_instance->m_actorWaitValue : 1 / 60;
+        double remaining = target - elapsed;
+        if (remaining * 1000.0 > 3.0)
+            Sleep(1);
+    }
+
+    return result;
+}
+
 void BusyLoopFix::Initialize()
 {
     if (!bEnabled)
     {
         return;
     }
-
-
 
     g_instance = this;
 
@@ -36,11 +53,35 @@ void BusyLoopFix::Initialize()
         return;
     }
 
-    m_hook = safetyhook::create_inline(target, PeekMessageW_Hook);
+    m_peekMessageHook = safetyhook::create_inline(target, PeekMessageW_Hook);
+
+    if (!Util::IsRunningUnderWine())
+    {
+        return;
+    }
+
+    GetElapsedTime = (GetElapsedTime_t*)Memory::PatternScan(baseModule, "48 83 EC ?? 48 8D 0D ?? ?? ?? ?? FF 15 ?? ?? ?? ?? 48 8B 05", "MGS 2 | MGS 3: GetElapsedTime");
+    auto targetActorWait = Memory::PatternScan(
+        baseModule,
+        !(eGameType & MGS2)
+        ? "48 83 EC ?? 48 8D 0D ?? ?? ?? ?? FF 15 ?? ?? ?? ?? 48 8B 05"
+        : "48 83 EC ?? E8 ?? ?? ?? ?? 83 3D ?? ?? ?? ?? ?? 74",
+        "MGS 2 | MGS 3: ActorWait"
+    );
+
+    if (!targetActorWait)
+    {
+        spdlog::info("MGS 3: BusyLoopFix - Failed to find ActorWait!");
+        return;
+    }
+
+    m_actorWaitValue = (double*)Memory::PatternScan(baseModule, "83 3D ?? ?? ?? ?? 00 ?? ?? F2 0F 10 0D", "MGS 2 | MGS 3: ActorWaitValue");
+    m_actorWaitHook = safetyhook::create_inline(reinterpret_cast<void*>(targetActorWait), ActorWait_Hook);
 }
 
 void BusyLoopFix::Shutdown()
 {
-    m_hook = {};
+    m_peekMessageHook = {};
+    m_actorWaitHook = {};
     g_instance = nullptr;
 }

--- a/src/fixes/busy_loop_fix.cpp
+++ b/src/fixes/busy_loop_fix.cpp
@@ -3,6 +3,9 @@
 #include "busy_loop_fix.hpp"
 #include "logging.hpp"
 #include "helper.hpp"
+#include <timeapi.h>
+
+#pragma comment(lib, "winmm.lib")
 
 static BusyLoopFix* g_instance = nullptr;
 typedef double GetElapsedTime_t();
@@ -20,41 +23,32 @@ BOOL WINAPI BusyLoopFix::PeekMessageW_Hook(LPMSG m, HWND h, UINT a, UINT b, UINT
     return r;
 }
 
-#include <windows.h>
-#include <timeapi.h>
-
-#pragma comment(lib, "winmm.lib")
-
 __int64 BusyLoopFix::ActorWait_Hook()
 {
-    
-    
     __int64 result = g_instance->m_actorWaitHook.call<__int64>();
 
     if (result == 0)
     {
         double elapsed = GetElapsedTime();
-        double target = 0.01666;
+        double target = g_instance->m_actorWaitValue ? *g_instance->m_actorWaitValue : 0.01666;
         double remaining = target - elapsed;
 
-        // sleep isn't perfectly accruate, so we only sleep if more than 3ms remain
-        if (remaining * 1000.0 > 3.0) {
-            //spdlog::info("sleep");
-            timeBeginPeriod(1);
+        if (remaining * 1000.0 > 2.0)
             Sleep(1);
-            timeEndPeriod(1);
-        }
     }
 
     return result;
 }
 
+uintptr_t GetRelativeOffset(uint8_t* addr)
+{
+    return reinterpret_cast<uintptr_t>(addr) + 4 + *reinterpret_cast<int32_t*>(addr);
+}
+
 void BusyLoopFix::Initialize()
 {
-    if (!bEnabled)
-    {
+    if (!iOption)
         return;
-    }
 
     g_instance = this;
 
@@ -68,19 +62,13 @@ void BusyLoopFix::Initialize()
 
     m_peekMessageHook = safetyhook::create_inline(target, PeekMessageW_Hook);
 
-    if (!Util::IsRunningUnderWine())
-    {
-        //return;
-    }
+    if (iOption == 1)
+        return;
+
+    timeBeginPeriod(1);
 
     GetElapsedTime = (GetElapsedTime_t*)Memory::PatternScan(baseModule, "48 83 EC ?? 48 8D 0D ?? ?? ?? ?? FF 15 ?? ?? ?? ?? 48 8B 05", "MGS 2 | MGS 3: GetElapsedTime");
-    auto targetActorWait = Memory::PatternScan(
-        baseModule,
-        !(eGameType & MGS2)
-        ? "48 83 EC ?? 48 8D 0D ?? ?? ?? ?? FF 15 ?? ?? ?? ?? 48 8B 05"
-        : "48 83 EC ?? E8 ?? ?? ?? ?? 83 3D ?? ?? ?? ?? ?? 74",
-        "MGS 2 | MGS 3: ActorWait"
-    );
+    auto targetActorWait = Memory::PatternScan(baseModule, "48 83 EC ?? E8 ?? ?? ?? ?? 83 3D ?? ?? ?? ?? ?? 74", "MGS 2 | MGS 3: ActorWait");
 
     if (!targetActorWait)
     {
@@ -88,7 +76,11 @@ void BusyLoopFix::Initialize()
         return;
     }
 
-    //m_actorWaitValue = (double*)Memory::PatternScan(baseModule, "83 3D ?? ?? ?? ?? 00 ?? ?? F2 0F 10 0D", "MGS 2 | MGS 3: ActorWaitValue");
+    auto targetActorWaitValue = Memory::PatternScan(baseModule, eGameType & MGS2 ? "83 3D ?? ?? ?? ?? ?? 74 ?? 66 0F 2F 05" : "83 3D ?? ?? ?? ?? 00 ?? ?? F2 0F 10 0D", "MGS 2 | MGS 3: ActorWaitValue");
+    
+    if (targetActorWaitValue)
+        m_actorWaitValue = reinterpret_cast<double*>((reinterpret_cast<uintptr_t>(targetActorWaitValue + 13) + 4 + *reinterpret_cast<int32_t*>(targetActorWaitValue + 13)));
+    
     m_actorWaitHook = safetyhook::create_inline(reinterpret_cast<void*>(targetActorWait), ActorWait_Hook);
 }
 
@@ -97,4 +89,6 @@ void BusyLoopFix::Shutdown()
     m_peekMessageHook = {};
     m_actorWaitHook = {};
     g_instance = nullptr;
+
+    timeEndPeriod(1);
 }

--- a/src/fixes/busy_loop_fix.cpp
+++ b/src/fixes/busy_loop_fix.cpp
@@ -20,17 +20,30 @@ BOOL WINAPI BusyLoopFix::PeekMessageW_Hook(LPMSG m, HWND h, UINT a, UINT b, UINT
     return r;
 }
 
+#include <windows.h>
+#include <timeapi.h>
+
+#pragma comment(lib, "winmm.lib")
+
 __int64 BusyLoopFix::ActorWait_Hook()
 {
+    
+    
     __int64 result = g_instance->m_actorWaitHook.call<__int64>();
 
     if (result == 0)
     {
         double elapsed = GetElapsedTime();
-        double target = g_instance->m_actorWaitValue ? *g_instance->m_actorWaitValue : 1 / 60;
+        double target = 0.01666;
         double remaining = target - elapsed;
-        if (remaining * 1000.0 > 3.0)
+
+        // sleep isn't perfectly accruate, so we only sleep if more than 3ms remain
+        if (remaining * 1000.0 > 3.0) {
+            //spdlog::info("sleep");
+            timeBeginPeriod(1);
             Sleep(1);
+            timeEndPeriod(1);
+        }
     }
 
     return result;
@@ -57,7 +70,7 @@ void BusyLoopFix::Initialize()
 
     if (!Util::IsRunningUnderWine())
     {
-        return;
+        //return;
     }
 
     GetElapsedTime = (GetElapsedTime_t*)Memory::PatternScan(baseModule, "48 83 EC ?? 48 8D 0D ?? ?? ?? ?? FF 15 ?? ?? ?? ?? 48 8B 05", "MGS 2 | MGS 3: GetElapsedTime");
@@ -75,7 +88,7 @@ void BusyLoopFix::Initialize()
         return;
     }
 
-    m_actorWaitValue = (double*)Memory::PatternScan(baseModule, "83 3D ?? ?? ?? ?? 00 ?? ?? F2 0F 10 0D", "MGS 2 | MGS 3: ActorWaitValue");
+    //m_actorWaitValue = (double*)Memory::PatternScan(baseModule, "83 3D ?? ?? ?? ?? 00 ?? ?? F2 0F 10 0D", "MGS 2 | MGS 3: ActorWaitValue");
     m_actorWaitHook = safetyhook::create_inline(reinterpret_cast<void*>(targetActorWait), ActorWait_Hook);
 }
 

--- a/src/fixes/busy_loop_fix.cpp
+++ b/src/fixes/busy_loop_fix.cpp
@@ -4,6 +4,7 @@
 #include "logging.hpp"
 #include "helper.hpp"
 #include <timeapi.h>
+#include <gamevars.hpp>
 
 #pragma comment(lib, "winmm.lib")
 
@@ -30,19 +31,17 @@ __int64 BusyLoopFix::ActorWait_Hook()
     if (result == 0)
     {
         double elapsed = GetElapsedTime();
-        double target = g_instance->m_actorWaitValue ? *g_instance->m_actorWaitValue : 0.01666;
+        double target = g_GameVars.ActorWaitValue();
         double remaining = target - elapsed;
 
-        if (remaining * 1000.0 > 2.0)
+        // sleep may not be fully accurate, even with timeBeginPeriod.
+        // a 3ms buffer should be more than enough to avoid overshooting our 
+        // wait and to reduce cpu usage
+        if (remaining * 1000.0 > 3.0) 
             Sleep(1);
     }
 
     return result;
-}
-
-uintptr_t GetRelativeOffset(uint8_t* addr)
-{
-    return reinterpret_cast<uintptr_t>(addr) + 4 + *reinterpret_cast<int32_t*>(addr);
 }
 
 void BusyLoopFix::Initialize()
@@ -56,7 +55,7 @@ void BusyLoopFix::Initialize()
 
     if (!target)
     {
-        spdlog::info("MGS 2 | MGS 3: BusyLoopFix - Failed to find PeekMessageW!");
+        spdlog::error("MGS 2 | MGS 3: BusyLoopFix - Failed to find PeekMessageW!");
         return;
     }
 
@@ -67,20 +66,23 @@ void BusyLoopFix::Initialize()
 
     timeBeginPeriod(1);
 
-    GetElapsedTime = (GetElapsedTime_t*)Memory::PatternScan(baseModule, "48 83 EC ?? 48 8D 0D ?? ?? ?? ?? FF 15 ?? ?? ?? ?? 48 8B 05", "MGS 2 | MGS 3: GetElapsedTime");
+    // MGSFPSUnlock hooks this function, so we pattern scan after the hook
+    GetElapsedTime = (GetElapsedTime_t*)(Memory::PatternScan(baseModule, "FF 15 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 0F 57 C0", "MGS 2 | MGS 3: GetElapsedTime") - 0xB);
+
+    if (!GetElapsedTime)
+    {
+        spdlog::error("MGS 2 | MGS 3: BusyLoopFix - Failed to find GetElapsedTime!");
+        return;
+    }
+    
     auto targetActorWait = Memory::PatternScan(baseModule, "48 83 EC ?? E8 ?? ?? ?? ?? 83 3D ?? ?? ?? ?? ?? 74", "MGS 2 | MGS 3: ActorWait");
 
     if (!targetActorWait)
     {
-        spdlog::info("MGS 3: BusyLoopFix - Failed to find ActorWait!");
+        spdlog::error("MGS 2 | MGS 3: BusyLoopFix - Failed to find ActorWait!");
         return;
     }
 
-    auto targetActorWaitValue = Memory::PatternScan(baseModule, eGameType & MGS2 ? "83 3D ?? ?? ?? ?? ?? 74 ?? 66 0F 2F 05" : "83 3D ?? ?? ?? ?? 00 ?? ?? F2 0F 10 0D", "MGS 2 | MGS 3: ActorWaitValue");
-    
-    if (targetActorWaitValue)
-        m_actorWaitValue = reinterpret_cast<double*>((reinterpret_cast<uintptr_t>(targetActorWaitValue + 13) + 4 + *reinterpret_cast<int32_t*>(targetActorWaitValue + 13)));
-    
     m_actorWaitHook = safetyhook::create_inline(reinterpret_cast<void*>(targetActorWait), ActorWait_Hook);
 }
 
@@ -90,5 +92,6 @@ void BusyLoopFix::Shutdown()
     m_actorWaitHook = {};
     g_instance = nullptr;
 
-    timeEndPeriod(1);
+    if (iOption > 1)
+        timeEndPeriod(1);
 }

--- a/src/fixes/busy_loop_fix.hpp
+++ b/src/fixes/busy_loop_fix.hpp
@@ -10,7 +10,7 @@ public:
     static __int64 ActorWait_Hook();
 
     bool bEnabled = false;
-    double* m_actorWaitValue;
+    double* m_actorWaitValue = nullptr;
 
 private:
     SafetyHookInline m_peekMessageHook;

--- a/src/fixes/busy_loop_fix.hpp
+++ b/src/fixes/busy_loop_fix.hpp
@@ -9,7 +9,7 @@ public:
     static BOOL WINAPI PeekMessageW_Hook(LPMSG m, HWND h, UINT a, UINT b, UINT c);
     static __int64 ActorWait_Hook();
 
-    bool bEnabled = false;
+    int iOption = 0;
     double* m_actorWaitValue = nullptr;
 
 private:

--- a/src/fixes/busy_loop_fix.hpp
+++ b/src/fixes/busy_loop_fix.hpp
@@ -7,10 +7,14 @@ public:
     void Initialize();
     void Shutdown();
     static BOOL WINAPI PeekMessageW_Hook(LPMSG m, HWND h, UINT a, UINT b, UINT c);
+    static __int64 ActorWait_Hook();
 
     bool bEnabled = false;
+    double* m_actorWaitValue;
+
 private:
-    SafetyHookInline m_hook;
+    SafetyHookInline m_peekMessageHook;
+    SafetyHookInline m_actorWaitHook;
 };
 
 inline BusyLoopFix g_BusyLoopFix;

--- a/src/fixes/busy_loop_fix.hpp
+++ b/src/fixes/busy_loop_fix.hpp
@@ -10,7 +10,6 @@ public:
     static __int64 ActorWait_Hook();
 
     int iOption = 0;
-    double* m_actorWaitValue = nullptr;
 
 private:
     SafetyHookInline m_peekMessageHook;

--- a/src/resources/config.cpp
+++ b/src/resources/config.cpp
@@ -611,9 +611,9 @@ void Config::Read()
     // Busy Loop Fix
     if (eGameType & (MG | MGS2 | MGS3))
     {
-        ConfigHelper::getValue(ini, ConfigKeys::BusyLoopFix_Section, ConfigKeys::BusyLoopFix_Enabled, g_BusyLoopFix.bEnabled);
+        ConfigHelper::getValue(ini, ConfigKeys::BusyLoopFix_Section, ConfigKeys::BusyLoopFix_Enabled, g_BusyLoopFix.iOption);
 
-        LOG_CONFIG(ConfigKeys::BusyLoopFix_Section, ConfigKeys::BusyLoopFix_Enabled, g_BusyLoopFix.bEnabled);
+        LOG_CONFIG(ConfigKeys::BusyLoopFix_Section, ConfigKeys::BusyLoopFix_Enabled, g_BusyLoopFix.iOption);
     }
 
     ConfigLogger::Flush();

--- a/src/resources/gamevars.cpp
+++ b/src/resources/gamevars.cpp
@@ -41,6 +41,7 @@ void GameVars::Initialize()
     {
         aimingState = reinterpret_cast<uint64_t*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "8B 35 ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ?? 49 89 8D", "MGS 3: GameVars: aimingState") + 2));
         heldTriggers = reinterpret_cast<uint32_t*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "48 8D 3D ?? ?? ?? ?? BA ?? ?? ?? ?? 41 B8", "MGS 3: GameVars: heldTriggers") + 3));
+        actorWaitValue = reinterpret_cast<double*>(Memory::GetRelativeOffset(Memory::PatternScan(baseModule, "83 3D ?? ?? ?? ?? 00 ?? ?? F2 0F 10 0D", "MGS 2: GameVars: actorWaitValue") + 13));
 
         spdlog::info("GameVars: aimingState address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)aimingState - (uintptr_t)baseModule);
         spdlog::info("GameVars: heldTriggers address is {:s}+{:X}", sExeName.c_str(), (uintptr_t)heldTriggers - (uintptr_t)baseModule);
@@ -66,6 +67,11 @@ bool GameVars::InCutscene() const //does not count pad demos or FMVs, only full 
 bool GameVars::InScriptedSequence() const //Scripted sequences, i.e., forced codec calls, cutscenes, pad demos (ingame tutorials & forced movements ala first meeting Stillman), and FMVs.
 {
     return scriptedSequenceFlag == nullptr ? false : (*scriptedSequenceFlag == 1);
+}
+
+double GameVars::ActorWaitValue() const
+{
+    return actorWaitValue == nullptr ? 1.0 / 60.0 : *actorWaitValue;
 }
 
 double GameVars::ActorWaitMultiplier() const

--- a/src/resources/gamevars.hpp
+++ b/src/resources/gamevars.hpp
@@ -7,6 +7,7 @@ public:
     [[nodiscard]] bool InCutscene() const; // If we're in a full demo cutscene.
     [[nodiscard]] bool InScriptedSequence() const; // If the game is in a scripted sequence (cutscene or pad demo).
     [[nodiscard]] double ActorWaitMultiplier() const;
+    [[nodiscard]] double ActorWaitValue() const;
 
     [[nodiscard]] std::string GetRichPresenceString() const;
     [[nodiscard]] std::string GetGameMode() const;

--- a/src/resources/helper.cpp
+++ b/src/resources/helper.cpp
@@ -411,6 +411,13 @@ namespace Util
         return "File description not found.";
     }
 
+    bool IsRunningUnderWine()
+    {
+        HMODULE ntdll = GetModuleHandleA("ntdll.dll");
+        if (!ntdll) return false;
+        return GetProcAddress(ntdll, "wine_get_version") != nullptr;
+    }
+
     ///Scans all valid ASI directories for any .asi files matching the fileName.
     bool CheckForASIFiles(std::string fileName, bool checkForDuplicates, bool setFixPath, const char* checkCreationDate)
     {

--- a/src/resources/helper.hpp
+++ b/src/resources/helper.hpp
@@ -54,6 +54,8 @@ namespace Util
 
     std::string GetFileDescription(const std::string& filePath);
 
+    bool IsRunningUnderWine();
+
     bool CheckForASIFiles(std::string fileName, bool checkForDuplicates, bool setFixPath, const char* checkCreationDate);
 
     std::string GetNameAtIndex(const std::initializer_list<std::string>& list, int index);


### PR DESCRIPTION
This only affects MGS2 and MGS3.

@Franatix93 had pointed out that sometimes MGS2 seemed to draw more power in certain sections of the game despite the previous PR which significantly reduced CPU usage. After further investigation, I noticed that under Linux one core could still end up being pegged to 100%. After doing some profiling, I saw that `QueryPerformanceCounter` under Wine was taking up the majority of the CPU time. The game busy waits until the next frame is ready, but apparently Wine's implementation for QPC has significantly more overhead causing the issue to be more apparent there. I think it was probably only noticeable in areas of the game where your framerate would exceed well over 60fps if it weren't for the frame cap (like menus). So, the solution is to determine how much longer we have left before the next frame is ready and just sleep.

`Fix High CPU Usage` now supports values of 0, 1, and 2, where 2 includes the changes in this PR.

Comparisons were done on my 12700k /w 16 threads enabled.

Before :
<img width="312" height="48" alt="image" src="https://github.com/user-attachments/assets/97d55139-da2a-416a-989d-072e493d70f8" />
<img width="328" height="50" alt="image" src="https://github.com/user-attachments/assets/23e73bd3-8d4c-4713-ade4-8f6a774397f5" />

After:
<img width="317" height="40" alt="image" src="https://github.com/user-attachments/assets/1bde399a-f4bb-4136-b10b-2aa2a07e48f2" />
<img width="321" height="48" alt="image" src="https://github.com/user-attachments/assets/a51cec4d-2396-4c88-9728-4ace97af0885" />