### PR TITLE
Snake-arms audio panning

### DIFF
--- a/MGSHDFix.vcxproj
+++ b/MGSHDFix.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\fixes\snakearm_voice.cpp" />
     <ClCompile Include="src\fixes\resolution_scaling_fixes.cpp" />
     <ClCompile Include="src\features\custom_resolution_and_borderless.cpp" />
     <ClCompile Include="src\features\mgs2_restore_dogtags.cpp" />
@@ -124,6 +125,7 @@
     <ClCompile Include="src\features\swap_menu_buttons.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\fixes\snakearm_voice.hpp" />
     <ClInclude Include="src\fixes\resolution_scaling_fixes.hpp" />
     <ClInclude Include="src\features\custom_resolution_and_borderless.hpp" />
     <ClInclude Include="src\features\mgs2_restore_dogtags.hpp" />

--- a/MGSHDFix.vcxproj.filters
+++ b/MGSHDFix.vcxproj.filters
@@ -173,6 +173,9 @@
     <ClCompile Include="src\features\swap_menu_buttons.cpp">
       <Filter>Features</Filter>
     </ClCompile>
+    <ClCompile Include="src\fixes\snakearm_voice.cpp">
+      <Filter>Fixes</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\fixes\line_scaling.hpp">
@@ -335,6 +338,9 @@
       <Filter>Fixes\Headers</Filter>
     </ClInclude>
     <ClInclude Include="src\fixes\resolution_scaling_fixes.hpp">
+      <Filter>Fixes\Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="src\fixes\snakearm_voice.hpp">
       <Filter>Fixes\Headers</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -52,6 +52,7 @@
 #include "mgs3_fix_holster_after_torture.hpp"
 #include "resolution_scaling_fixes.hpp"
 #include "swap_menu_buttons.hpp"
+#include "snakearm_voice.hpp"
 //#include "texture_buffer_size.hpp" //disabled for now, the vanilla limit was increased to 128MB/texture in 2.0.0, so there's no much need until 8k gaming is standard & there's a need for a 16k texture pack lol.
 
 
@@ -472,6 +473,7 @@ static void InitializeSubsystems()
     INITIALIZE(ResolutionScalingFixes::ApplyFixes()); // Always load after custom resolution
 
     INITIALIZE(g_BusyLoopFix.Initialize());
+    INITIALIZE(SnakeArmFixes::ApplyFixes());
 
 #if !defined(RELEASE_BUILD) //todo category
     //todo: Make ultrawide reposition HUD elements correctly instead of stretching them

--- a/src/fixes/snakearm_voice.cpp
+++ b/src/fixes/snakearm_voice.cpp
@@ -18,15 +18,14 @@ void SnakeArmFixes::ApplyFixes() {
     }
 
     // user/sonoyama/solidus/init_sol.c -> InitControl
-    // Get SOL_SolControl (not sure how to properly optimize the pattern)
-    //4B 8B CD 45 8D 41 EC E8 ?? ?? ?? ?? 44 8B 8D D8 00 00 00 
-    //41 B8 0F 00 00 00 8B 8D C4 00 00 00 48 8B D5 E8 ?? ?? ?? ?? A8 01 74 07 E8 ?? ?? ?? ?? 
+    // Get SOL_SolControl (unsure how to properly optimize the pattern, more context attached)
+    //   4B 8B CD 45 8D 41 EC E8 ?? ?? ?? ?? 44 8B 8D D8 00 00 00 
+    //   41 B8 0F 00 00 00 8B 8D C4 00 00 00 48 8B D5 E8 ?? ?? ?? ?? A8 01 74 07 E8 ?? ?? ?? ?? 
     uint8_t* Solidus_InitControl = Memory::PatternScan(baseModule, "EB 05 F3 0F 10 47 64 F3 0F 10 0D ?? ?? ?? ?? 0F 28 D0 48 8B CD E8 ?? ?? ?? ?? 8B D6 48 89 2D", "Solidus Voice Position");
     SolControl = (uintptr_t*)Memory::GetRelativeOffset(Solidus_InitControl + 31);
-    // // Free pointer! Use to match lea instruction.
-    // Memory::Write((uintptr_t)SolControl + 0x40, SolControl);
 
     // user/sonoyama/solidus/snakearm.c -> ClawAttackHit - uses GM_PlayerPosition instead of SOL_SolControl->mov
+    // Same for OnlineHit
     // This is probably not the correct way to change an offset from one global to another.
     uint8_t* ClawAttackHit = Memory::PatternScan(baseModule, "2B C8 48 8D 15 ?? ?? ?? ?? 8B C1 48 8D 0D ?? ?? ?? ?? 8B 0C 81 48 8B", "Solidus Voice Position Fix");
     uint8_t* OnlineHit = Memory::PatternScan(baseModule, "2B C8 48 8D 15 ?? ?? ?? ?? 8B C1 48 8D 0D ?? ?? ?? ?? 8B 0C 81 E8", "Solidus Voice Position Fix 2");
@@ -40,33 +39,34 @@ void SnakeArmFixes::ApplyFixes() {
         Memory::PatchBytes((uintptr_t)OnlineHit + 2, "\x90\x90\x90\x90\x90\x90\x90", 7);
         
         {
-            static SafetyHookMid hook__unique22{};
-            hook__unique22 = safetyhook::create_mid(ClawAttackHit + 2, [](SafetyHookContext& ctx) { {
-                    ctx.rdx = *SolControl;
-                } }); 
-            if (hook__unique22) {
-                if (g_Logging.bVerboseLogging) {
-                    spdlog::info("Solidus Voice Position: Hook 1 installed.");
-                }
-            }
-            else {
-                spdlog::error("Solidus Voice Position: Hook 1 failed.");
-            }
-
-            static SafetyHookMid hook__unique23{};
-            hook__unique23 = safetyhook::create_mid(OnlineHit + 2, [](SafetyHookContext& ctx) { {
+            static SafetyHookMid ClawAttackHook{};
+            ClawAttackHook = safetyhook::create_mid(ClawAttackHit + 2, [](SafetyHookContext& ctx) { {
                     ctx.rdx = *SolControl;
                 } });
-            if (hook__unique23) {
+
+            static SafetyHookMid OnlineHitHook{};
+            OnlineHitHook = safetyhook::create_mid(OnlineHit + 2, [](SafetyHookContext& ctx) { {
+                    ctx.rdx = *SolControl;
+                } });
+
+            if (ClawAttackHook && OnlineHitHook) {
                 if (g_Logging.bVerboseLogging) {
-                    spdlog::info("Solidus Voice Position: Hook 2 installed.");
+                    spdlog::info("Solidus Voice Position: Hooks installed.");
                 }
             }
-            else {
+            else if (ClawAttackHook) {
                 spdlog::error("Solidus Voice Position: Hook 2 failed.");
+            }
+            else if (OnlineHitHook) {
+                spdlog::error("Solidus Voice Position: Hook 1 failed.");
+            }
+            else {
+                spdlog::error("Solidus Voice Position: Hooks failed.");
             }
             
         }
-        spdlog::info("sol goodman.");
+    }
+    else {
+        spdlog::error("Solidus Voice Position: Failed to match one or more hook locations.");
     }
 }

--- a/src/fixes/snakearm_voice.cpp
+++ b/src/fixes/snakearm_voice.cpp
@@ -1,0 +1,72 @@
+#include "stdafx.h"
+
+#include "snakearm_voice.hpp"
+
+#include "common.hpp"
+#include "custom_resolution_and_borderless.hpp"
+#include "logging.hpp"
+
+namespace
+{
+    uintptr_t* SolControl = NULL;
+}
+
+void SnakeArmFixes::ApplyFixes() {
+    if (!(eGameType & MGS2))
+    {
+        return;
+    }
+
+    // user/sonoyama/solidus/init_sol.c -> InitControl
+    // Get SOL_SolControl (not sure how to properly optimize the pattern)
+    //4B 8B CD 45 8D 41 EC E8 ?? ?? ?? ?? 44 8B 8D D8 00 00 00 
+    //41 B8 0F 00 00 00 8B 8D C4 00 00 00 48 8B D5 E8 ?? ?? ?? ?? A8 01 74 07 E8 ?? ?? ?? ?? 
+    uint8_t* Solidus_InitControl = Memory::PatternScan(baseModule, "EB 05 F3 0F 10 47 64 F3 0F 10 0D ?? ?? ?? ?? 0F 28 D0 48 8B CD E8 ?? ?? ?? ?? 8B D6 48 89 2D", "Solidus Voice Position");
+    SolControl = (uintptr_t*)Memory::GetRelativeOffset(Solidus_InitControl + 31);
+    // // Free pointer! Use to match lea instruction.
+    // Memory::Write((uintptr_t)SolControl + 0x40, SolControl);
+
+    // user/sonoyama/solidus/snakearm.c -> ClawAttackHit - uses GM_PlayerPosition instead of SOL_SolControl->mov
+    // This is probably not the correct way to change an offset from one global to another.
+    uint8_t* ClawAttackHit = Memory::PatternScan(baseModule, "2B C8 48 8D 15 ?? ?? ?? ?? 8B C1 48 8D 0D ?? ?? ?? ?? 8B 0C 81 48 8B", "Solidus Voice Position Fix");
+    uint8_t* OnlineHit = Memory::PatternScan(baseModule, "2B C8 48 8D 15 ?? ?? ?? ?? 8B C1 48 8D 0D ?? ?? ?? ?? 8B 0C 81 E8", "Solidus Voice Position Fix 2");
+
+    if (Solidus_InitControl && ClawAttackHit && OnlineHit) {
+        // int32_t SolControl_Relative = (int32_t)(/*(long)&SolControl*/ (uintptr_t)SolControl + 0x40 - (long)ClawAttackHit - 9);
+        // Memory::Write((uintptr_t)(ClawAttackHit + 5), SolControl_Relative);
+        // SPDLOG_INFO("Solidus Voice Position: Write value {}", SolControl_Relative);
+        
+        Memory::PatchBytes((uintptr_t)ClawAttackHit + 2, "\x90\x90\x90\x90\x90\x90\x90", 7);
+        Memory::PatchBytes((uintptr_t)OnlineHit + 2, "\x90\x90\x90\x90\x90\x90\x90", 7);
+        
+        {
+            static SafetyHookMid hook__unique22{};
+            hook__unique22 = safetyhook::create_mid(ClawAttackHit + 2, [](SafetyHookContext& ctx) { {
+                    ctx.rdx = *SolControl;
+                } }); 
+            if (hook__unique22) {
+                if (g_Logging.bVerboseLogging) {
+                    spdlog::info("Solidus Voice Position: Hook 1 installed.");
+                }
+            }
+            else {
+                spdlog::error("Solidus Voice Position: Hook 1 failed.");
+            }
+
+            static SafetyHookMid hook__unique23{};
+            hook__unique23 = safetyhook::create_mid(OnlineHit + 2, [](SafetyHookContext& ctx) { {
+                    ctx.rdx = *SolControl;
+                } });
+            if (hook__unique23) {
+                if (g_Logging.bVerboseLogging) {
+                    spdlog::info("Solidus Voice Position: Hook 2 installed.");
+                }
+            }
+            else {
+                spdlog::error("Solidus Voice Position: Hook 2 failed.");
+            }
+            
+        }
+        spdlog::info("sol goodman.");
+    }
+}

--- a/src/fixes/snakearm_voice.hpp
+++ b/src/fixes/snakearm_voice.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace SnakeArmFixes
+{
+    void ApplyFixes();
+}


### PR DESCRIPTION
Fix for issue on line 52 of the community bug tracker, "Solidus's audio lines when his tentacle arm strikes are L1 blocked comes from Raiden's position instead of Solidus". Seen https://imgur.com/a/L0RuZVH.

Simply hooks the impacted attacks to set the position pointer-containing register to Solidus's object.

Fix demo: https://youtu.be/urTUQmoACvY (Testing without recording does not lag like this, I think it's just a bad laptop, but a second opinion would be welcome regardless.)

As this is my first contribution, any advice on pattern matching or naming conventions would also be appreciated.