### PR TITLE
Mgs2 codec ghost frames, loading / pause ghosts, and codec crt sync line

### DIFF
--- a/MGSHDFix.vcxproj
+++ b/MGSHDFix.vcxproj
@@ -76,6 +76,7 @@
     <ClCompile Include="src\fixes\mgs2_demo_scope.cpp" />
     <ClCompile Include="src\fixes\mgs2_scope_warp.cpp" />
     <ClCompile Include="src\fixes\mgs2_water_effects.cpp" />
+    <ClCompile Include="src\fixes\mgs2_codec_band.cpp" />
     <ClCompile Include="src\fixes\mgs2_lens_droplets.cpp" />
     <ClCompile Include="src\fixes\mgs2_gas_haze.cpp" />
     <ClCompile Include="src\fixes\mgs2_demo_blur.cpp" />
@@ -230,6 +231,7 @@
     <ClInclude Include="src\fixes\mgs2_demo_scope.hpp" />
     <ClInclude Include="src\fixes\mgs2_scope_warp.hpp" />
     <ClInclude Include="src\fixes\mgs2_water_effects.hpp" />
+    <ClInclude Include="src\fixes\mgs2_codec_band.hpp" />
     <ClInclude Include="src\fixes\mgs2_lens_droplets.hpp" />
     <ClInclude Include="src\fixes\mgs2_gas_haze.hpp" />
     <ClInclude Include="src\fixes\mgs2_demo_blur.hpp" />

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -41,6 +41,7 @@
 #include "mgs2_demo_scope.hpp"
 #include "mgs2_scope_warp.hpp"
 #include "mgs2_water_effects.hpp"
+#include "mgs2_codec_band.hpp"
 #include "mgs2_lens_droplets.hpp"
 #include "mgs2_gas_haze.hpp"
 #include "mgs2_demo_camera_judder.hpp"
@@ -581,6 +582,7 @@ static void InitializeSubsystems()
         INITIALIZE(MGS2DemoScope::Initialize());
         INITIALIZE(MGS2ScopeWarp::Initialize());
         INITIALIZE(MGS2WaterEffects::Initialize());
+        INITIALIZE(MGS2CodecBand::Initialize());
         INITIALIZE(MGS2LensDroplets::Initialize());
         INITIALIZE(MGS2GasHaze::Initialize());
         INITIALIZE(MGS2DemoCameraJudder::Initialize());

--- a/src/fixes/mgs2_codec_band.cpp
+++ b/src/fixes/mgs2_codec_band.cpp
@@ -1,0 +1,48 @@
+#include "stdafx.h"
+#include "mgs2_codec_band.hpp"
+
+#include "common.hpp"
+#include "logging.hpp"
+
+// The port computes the codec CRT band's off-screen wait as 2*height ticks (~3s); the PS2 divided
+// by 8 sixteenths (~0.2s), so the band should re-enter almost immediately.
+
+namespace
+{
+    SafetyHookMid TrBufferHeight_hooks[2] {};
+}
+
+void MGS2CodecBand::Initialize()
+{
+    if (!(eGameType & MGS2) || !bEnabled)
+    {
+        return;
+    }
+
+    // The draw passes the band's box bottom as the TrBuffer height, so the renderer's vertical scale
+    // shrinks as the band descends and the sweep eases out - feed it the window height instead.
+    auto sites = Memory::FindMultiplePatternMatches(baseModule,
+        "F3 0F 11 4C 24 20 0F 57 C9 E8 ?? ?? ?? ?? 48 BA A9 00 00 00 64 00 00 00");
+    if (sites.size() == 2)
+    {
+        for (int i = 0; i < 2; i++)
+        {
+            TrBufferHeight_hooks[i] = safetyhook::create_mid(sites[i], [](SafetyHookContext& ctx) {
+                ctx.xmm1.f32[0] = static_cast<float>(*reinterpret_cast<const int32_t*>(ctx.rbx + 0x74));
+            });
+            LOG_HOOK(TrBufferHeight_hooks[i], "MGS 2: Codec Band: user\\mode\\codec\\codeccrt.c -> proc_black_zone() | TrBuffer height")
+        }
+    }
+    else
+    {
+        spdlog::error("MGS 2: Codec Band: expected 2 TrBuffer sites, found {}.", sites.size());
+    }
+
+    MAKE_HOOK_MID(baseModule, "89 83 A4 00 00 00 75 ?? F3 0F", "MGS 2: Codec Band: user\\mode\\codec\\codeccrt.c -> init_black_zone() | wait store", {
+        ctx.rax >>= 4;
+    });
+
+    MAKE_HOOK_MID(baseModule, "89 81 A4 00 00 00 F6 05", "MGS 2: Codec Band: user\\mode\\codec\\codeccrt.c -> proc_black_zone() | wait store", {
+        ctx.rax >>= 4;
+    });
+}

--- a/src/fixes/mgs2_codec_band.cpp
+++ b/src/fixes/mgs2_codec_band.cpp
@@ -38,11 +38,11 @@ void MGS2CodecBand::Initialize()
         spdlog::error("MGS 2: Codec Band: expected 2 TrBuffer sites, found {}.", sites.size());
     }
 
-    MAKE_HOOK_MID(baseModule, "89 83 A4 00 00 00 75 ?? F3 0F", "MGS 2: Codec Band: user\\mode\\codec\\codeccrt.c -> init_black_zone() | wait store", {
+    MAKE_HOOK_MID(baseModule, "89 83 ?? ?? ?? ?? 75 ?? F3 0F 58 0D", "MGS 2: Codec Band: user\\mode\\codec\\codeccrt.c -> init_black_zone() | wait store", {
         ctx.rax >>= 4;
     });
 
-    MAKE_HOOK_MID(baseModule, "89 81 A4 00 00 00 F6 05", "MGS 2: Codec Band: user\\mode\\codec\\codeccrt.c -> proc_black_zone() | wait store", {
+    MAKE_HOOK_MID(baseModule, "89 81 ?? ?? ?? ?? F6 05 ?? ?? ?? ?? ?? F3 0F 58 CA", "MGS 2: Codec Band: user\\mode\\codec\\codeccrt.c -> proc_black_zone() | wait store", {
         ctx.rax >>= 4;
     });
 }

--- a/src/fixes/mgs2_codec_band.hpp
+++ b/src/fixes/mgs2_codec_band.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace MGS2CodecBand
+{
+    inline bool bEnabled = true;
+    void Initialize();
+}

--- a/src/fixes/mgs2_demo_blur.cpp
+++ b/src/fixes/mgs2_demo_blur.cpp
@@ -363,6 +363,11 @@ void MGS2DemoBlur::CaptureFrame(ID3D11RenderTargetView* sceneColor, ID3D11Shader
     g_havePrev = true;
 }
 
+void MGS2DemoBlur::InvalidateCapture()
+{
+    g_havePrev = false;
+}
+
 void MGS2DemoBlur::Initialize()
 {
     if (!(eGameType & MGS2) || !bEnabled) return;

--- a/src/fixes/mgs2_demo_blur.hpp
+++ b/src/fixes/mgs2_demo_blur.hpp
@@ -8,6 +8,7 @@ namespace MGS2DemoBlur
 {
     void Initialize();
     void DrawInto(ID3D11RenderTargetView* sceneColor, ID3D11ShaderResourceView* depth);
+    void InvalidateCapture();
     void CaptureFrame(ID3D11RenderTargetView* sceneColor, ID3D11ShaderResourceView* depth);
     bool IsFeedbackActive();
 

--- a/src/fixes/mgs2_gas_haze.cpp
+++ b/src/fixes/mgs2_gas_haze.cpp
@@ -630,6 +630,11 @@ void MGS2GasHaze::OnFeedbackCapture(ID3D11RenderTargetView* sceneColor, ID3D11Sh
     g_lastCapFrame = g_D3D11Hooks.FrameCount;
 }
 
+void MGS2GasHaze::InvalidateCapture()
+{
+    g_lastCapFrame = UINT64_MAX;
+}
+
 void MGS2GasHaze::Initialize()
 {
     if (!(eGameType & MGS2))

--- a/src/fixes/mgs2_gas_haze.hpp
+++ b/src/fixes/mgs2_gas_haze.hpp
@@ -9,6 +9,7 @@ namespace MGS2GasHaze
     void DrawIntoCurrentTarget();
     void DrawInto(ID3D11RenderTargetView* sceneColor, ID3D11ShaderResourceView* depth);
     void OnPreMenuRender(ID3D11RenderTargetView* sceneColor, ID3D11ShaderResourceView* depth);
+    void InvalidateCapture();
     void OnFeedbackCapture(ID3D11RenderTargetView* sceneColor, ID3D11ShaderResourceView* depth);
     bool IsActive();
 

--- a/src/fixes/mgs2_underwater_filter.cpp
+++ b/src/fixes/mgs2_underwater_filter.cpp
@@ -1261,6 +1261,12 @@ namespace
             return false;
         }
 
+        // scr_water.c's WaterVisible() also hides the film through the START pause.
+        if ((g_GameVars.GV_PauseLevel() & MGS2_GV_PAUSE_PAUSE) != 0)
+        {
+            return false;
+        }
+
         return true;
     }
 
@@ -1669,11 +1675,15 @@ void MGS2UnderwaterFilterFix::PatchWork(void* work) const
         gScrWaterSawUnderwaterStep = true;
     }
 
-    const bool codecFallback = step == 0 && !gScrWaterSawUnderwaterStep && IsUnderwaterCodecSequence();
+    // Radio only - the RADAR|GAGE combo matches ordinary wet gameplay HUD.
+    const bool codecFallback = step == 0 && !gScrWaterSawUnderwaterStep && IsPlayerInWater() &&
+        (g_GameVars.GM_MenuStatus() & MENU_RADIO_ON) != 0;
     const bool active = ((step >= 1 && step <= 2) || codecFallback) && IsWaterVisible();
     gScrWaterActive = active;
 
     dmapack->flag |= kDmapackMenu;
+    // Channels 2/3 are the codec face windows - the fullscreen film squashes into them.
+    dmapack->flag |= kDmapackInvisible2 | kDmapackInvisible3;
     dmapack->priority = kScrWaterPriority;
     if (active)
     {
@@ -1685,6 +1695,11 @@ void MGS2UnderwaterFilterFix::PatchWork(void* work) const
     }
 
     PatchPacket(info.packetMem, false);
+}
+
+void MGS2UnderwaterFilterFix::InvalidateCapture()
+{
+    gOwnedWaterFeedbackHasFrame = false;
 }
 
 void MGS2UnderwaterFilterFix::BeforePresent()

--- a/src/fixes/mgs2_underwater_filter.hpp
+++ b/src/fixes/mgs2_underwater_filter.hpp
@@ -8,6 +8,7 @@ public:
     void Initialize();
     void PatchWork(void* work) const;
     void BeforePresent();
+    void InvalidateCapture();
     void InstallD3D11StateHooks();
 };
 

--- a/src/resources/config.cpp
+++ b/src/resources/config.cpp
@@ -18,6 +18,7 @@
 #include "mgs2_gas_haze.hpp"
 #include "mgs2_demo_blur.hpp"
 #include "mgs2_demo_camera_judder.hpp"
+#include "mgs2_codec_band.hpp"
 #include "mgs2_reverb_wet_level.hpp"
 #include "mgs2_preshade_lights.hpp"
 #include "mgs2_tanker_snake_snap.hpp"
@@ -718,7 +719,7 @@ void Config::Read()
 
         if (eGameType & MGS2)
         {
-            g_MGS2UnderwaterFilterFix.bEnabled = g_OpticalCamoFix.bEnabled = MGS2BloodStains::bEnabled = MGS2ScopeWarp::bEnabled = MGS2WaterEffects::bEnabled = MGS2LensDroplets::bEnabled = MGS2GasHaze::bEnabled = MGS2_ContrastShader::bEnabled = MGS2_AiRayVision::bEnabled = MGS2_Crossfade::bEnabled = MGS2ConcentrateBlur::bEnabled = MGS2RailgunBeam::bEnabled = MGS2DemoCameraJudder::bEnabled = MGS2PreshadeLights::bEnabled = MGS2TankerSnakeSnap::bEnabled = MGS2HairLayering::bEnabled = MGS2_CodecBackground::bEnabled = bRestoreVFX;
+            g_MGS2UnderwaterFilterFix.bEnabled = g_OpticalCamoFix.bEnabled = MGS2BloodStains::bEnabled = MGS2ScopeWarp::bEnabled = MGS2WaterEffects::bEnabled = MGS2LensDroplets::bEnabled = MGS2GasHaze::bEnabled = MGS2_ContrastShader::bEnabled = MGS2_AiRayVision::bEnabled = MGS2_Crossfade::bEnabled = MGS2ConcentrateBlur::bEnabled = MGS2RailgunBeam::bEnabled = MGS2DemoCameraJudder::bEnabled = MGS2PreshadeLights::bEnabled = MGS2TankerSnakeSnap::bEnabled = MGS2HairLayering::bEnabled = MGS2_CodecBackground::bEnabled = MGS2CodecBand::bEnabled = bRestoreVFX;
 
             std::string sMotionBlur;
             ConfigHelper::getValue(ini, ConfigKeys::MotionBlur_Section, ConfigKeys::MotionBlur_Setting, sMotionBlur);

--- a/src/resources/d3d11_api.cpp
+++ b/src/resources/d3d11_api.cpp
@@ -19,6 +19,8 @@
 #include "mgs2_first_person_view_mode.hpp"
 #include "mgs2_thermal_goggles.hpp"
 #include "mgs2_underwater_filter.hpp"
+#include "mgs2_demo_blur.hpp"
+#include "mgs2_gas_haze.hpp"
 #include "d3d11_text_overlay.hpp"
 #include "mg1_display_scaling.hpp"
 #include "mgs2_crossfade.hpp"
@@ -139,6 +141,43 @@ namespace
         }
 
         const bool undrawn = IsUnDrawnFrame();
+
+        // A stage boundary invalidates the held frame and every frame-feedback capture, or the
+        // old scene replays into the new stage's first frames.
+        static std::string s_heldStage;
+        static int64_t s_lastUndrawCount = 0;
+        static int s_parkSyncFrames = 0;
+        const int64_t undrawCount = g_GameVars.DG_UnDrawFrameCount();
+        const char* stage = g_GameVars.GetCurrentStage();
+        if ((stage && s_heldStage != stage) || s_lastUndrawCount > kMaxHeldRun)
+        {
+            g_heldValid = false;
+            if (eGameType & MGS2)
+            {
+                MGS2DemoBlur::InvalidateCapture();
+                MGS2GasHaze::InvalidateCapture();
+                g_MGS2UnderwaterFilterFix.InvalidateCapture();
+            }
+            if (stage)
+            {
+                s_heldStage = stage;
+            }
+        }
+        if (undrawCount > kMaxHeldRun && s_lastUndrawCount <= kMaxHeldRun)
+        {
+            s_parkSyncFrames = 4;
+        }
+        s_lastUndrawCount = undrawCount;
+
+        // During loading the port shows its two internal frame buffers in turns. If they differ,
+        // the old frame flashes on screen - so make them equal when the load starts.
+        if (s_parkSyncFrames > 0 && undrawCount > kMaxHeldRun)
+        {
+            s_parkSyncFrames--;
+            SceneDepth::SyncRecentSceneTargets();
+            return;
+        }
+
         if ((undrawn || doubleRendered) && g_heldValid)
         {
             if (g_Logging.bVerboseLogging)
@@ -147,6 +186,11 @@ namespace
                     undrawn ? "undrawn" : "double-rendered", g_GameVars.GetCurrentStage());
             }
             context->CopyResource(backbuffer.Get(), g_heldFrame.Get());
+            return;
+        }
+
+        if (undrawn)
+        {
             return;
         }
 

--- a/src/resources/scene_depth.cpp
+++ b/src/resources/scene_depth.cpp
@@ -20,6 +20,7 @@ namespace
     // 3D-pass tracking, for the end-of-3D transition (draw effects under the UI).
     ComPtr<ID3D11Texture2D>          g_sceneDepth;     // the scene depth currently bound
     ComPtr<ID3D11RenderTargetView>   g_sceneColorRTV;  // colour RT bound alongside it
+    ComPtr<ID3D11RenderTargetView>   g_recentSceneRTVs[2];
     bool g_in3D = false;
     bool g_fired = false;
     UINT g_bbArea = 0;
@@ -333,7 +334,15 @@ namespace
                     {
                         g_sceneDepth = tex;
                         if (numViews > 0 && rtvs && rtvs[0])
+                        {
                             g_sceneColorRTV = rtvs[0];
+                            // Both parities of the internal frame target, for the loading sync.
+                            if (g_recentSceneRTVs[0].Get() != rtvs[0])
+                            {
+                                g_recentSceneRTVs[1] = g_recentSceneRTVs[0];
+                                g_recentSceneRTVs[0] = rtvs[0];
+                            }
+                        }
                     }
                 }
             }
@@ -387,6 +396,40 @@ void SceneDepth::OnPreMenuRender()
             if (entry.callback) entry.callback(g_sceneColorRTV.Get(), depthSRV);
         g_inOverlayCb = false;
     }
+}
+
+void SceneDepth::SyncRecentSceneTargets()
+{
+    ID3D11DeviceContext* ctx = g_D3D11Hooks.d3dDeviceContext.Get();
+    if (!ctx || !g_recentSceneRTVs[0] || !g_recentSceneRTVs[1])
+    {
+        return;
+    }
+
+    // Copy the fresh parity over the stale one - clearing either flickers what's on screen.
+    ComPtr<ID3D11Resource> fresh, stale;
+    g_recentSceneRTVs[0]->GetResource(fresh.GetAddressOf());
+    g_recentSceneRTVs[1]->GetResource(stale.GetAddressOf());
+    if (!fresh || !stale || fresh == stale)
+    {
+        return;
+    }
+
+    ComPtr<ID3D11Texture2D> freshTex, staleTex;
+    if (FAILED(fresh.As(&freshTex)) || FAILED(stale.As(&staleTex)) || !freshTex || !staleTex)
+    {
+        return;
+    }
+    D3D11_TEXTURE2D_DESC fd {}, sd {};
+    freshTex->GetDesc(&fd);
+    staleTex->GetDesc(&sd);
+    if (fd.Width != sd.Width || fd.Height != sd.Height || fd.Format != sd.Format ||
+        fd.SampleDesc.Count != sd.SampleDesc.Count)
+    {
+        return;
+    }
+
+    ctx->CopyResource(stale.Get(), fresh.Get());
 }
 
 void SceneDepth::ResetStatus()

--- a/src/resources/scene_depth.hpp
+++ b/src/resources/scene_depth.hpp
@@ -30,6 +30,7 @@ namespace SceneDepth
 
     void Initialize();
     void ResetStatus();
+    void SyncRecentSceneTargets();
     ID3D11ShaderResourceView* GetSRV();
     bool IsAvailable();
     ID3D11ShaderResourceView* CaptureDepth(ID3D11DepthStencilView* depthStencil);


### PR DESCRIPTION
The underwater effect was too broad, and marked a feedback frame active for being wet!
CRT sync lines were "broken" in PS2 so they worked, I broke them here too (if _PSX2!?).
Frame holdovers for loading etc, properly handled.