### PR TITLE
Persist FPV shooter mode across rooms

### DIFF
--- a/ConfigTool/tab_data.cpp
+++ b/ConfigTool/tab_data.cpp
@@ -393,24 +393,26 @@ std::nullopt, false, Field::Int, 100, 1, 100},
         { (MGS2), ConfigKeys::MGS2_First_Person_View_Hold_Button_Section, ConfigKeys::MGS2_First_Person_View_Hold_Button_Setting, ConfigKeys::MGS2_First_Person_View_Hold_Button_Help, ConfigKeys::MGS2_First_Person_View_Hold_Button_Tooltip,
           std::nullopt, false, Field::Bool, false },
 
-
         { (MGS2), ConfigKeys::MGS2_First_Person_View_Hold_ToggleKey_Section, ConfigKeys::MGS2_First_Person_View_Hold_ToggleKey_Setting, ConfigKeys::MGS2_First_Person_View_Hold_ToggleKey_Help, ConfigKeys::MGS2_First_Person_View_Hold_ToggleKey_Tooltip,
-        std::make_pair(ConfigKeys::MGS2_First_Person_View_Hold_Button_Section, ConfigKeys::MGS2_First_Person_View_Hold_Button_Setting), false, Field::Hotkey, 0, 0, 0, "Up" },
+          std::make_pair(ConfigKeys::MGS2_First_Person_View_Hold_Button_Section, ConfigKeys::MGS2_First_Person_View_Hold_Button_Setting), false, Field::Hotkey, 0, 0, 0, "Up" },
+        
 
-
-
-      { (MGS2), ConfigKeys::MGS2_First_Person_View_Enabled_Section, ConfigKeys::MGS2_First_Person_View_Enabled_Setting, ConfigKeys::MGS2_First_Person_View_Enabled_Help, ConfigKeys::MGS2_First_Person_View_Enabled_Tooltip,
-            std::nullopt, false, Field::Bool, false },
+        { (MGS2), ConfigKeys::MGS2_First_Person_View_Enabled_Section, ConfigKeys::MGS2_First_Person_View_Enabled_Setting, ConfigKeys::MGS2_First_Person_View_Enabled_Help, ConfigKeys::MGS2_First_Person_View_Enabled_Tooltip,
+          std::nullopt, false, Field::Bool, false },
 
         { (MGS2), ConfigKeys::MGS2_First_Person_View_ToggleKey_Section, ConfigKeys::MGS2_First_Person_View_ToggleKey_Setting, ConfigKeys::MGS2_First_Person_View_ToggleKey_Help, ConfigKeys::MGS2_First_Person_View_ToggleKey_Tooltip,
-            std::make_pair(ConfigKeys::MGS2_First_Person_View_Enabled_Section, ConfigKeys::MGS2_First_Person_View_Enabled_Setting), false, Field::Hotkey, 0, 0, 0, "Right" },
+          std::make_pair(ConfigKeys::MGS2_First_Person_View_Enabled_Section, ConfigKeys::MGS2_First_Person_View_Enabled_Setting), false, Field::Hotkey, 0, 0, 0, "Right" },
 
 
         { (MGS2), ConfigKeys::MGS2_First_Person_View_Movement_Enabled_By_Default_Section, ConfigKeys::MGS2_First_Person_View_Movement_Enabled_By_Default_Setting, ConfigKeys::MGS2_First_Person_View_Movement_Enabled_By_Default_Help, ConfigKeys::MGS2_First_Person_View_Movement_Enabled_By_Default_Tooltip,
-            std::make_pair(ConfigKeys::MGS2_First_Person_View_Enabled_Section, ConfigKeys::MGS2_First_Person_View_Enabled_Setting), false, Field::Bool, true },
+          std::make_pair(ConfigKeys::MGS2_First_Person_View_Enabled_Section, ConfigKeys::MGS2_First_Person_View_Enabled_Setting), false, Field::Bool, true },
 
-      { (MGS2), ConfigKeys::MGS2_First_Person_View_Movement_ToggleKey_Section, ConfigKeys::MGS2_First_Person_View_Movement_ToggleKey_Setting, ConfigKeys::MGS2_First_Person_View_Movement_ToggleKey_Help, ConfigKeys::MGS2_First_Person_View_Movement_ToggleKey_Tooltip,
-            std::make_pair(ConfigKeys::MGS2_First_Person_View_Enabled_Section, ConfigKeys::MGS2_First_Person_View_Enabled_Setting), false, Field::Hotkey, 0, 0, 0, "Down" },
+        { (MGS2), ConfigKeys::MGS2_First_Person_View_Movement_ToggleKey_Section, ConfigKeys::MGS2_First_Person_View_Movement_ToggleKey_Setting, ConfigKeys::MGS2_First_Person_View_Movement_ToggleKey_Help, ConfigKeys::MGS2_First_Person_View_Movement_ToggleKey_Tooltip,
+          std::make_pair(ConfigKeys::MGS2_First_Person_View_Enabled_Section, ConfigKeys::MGS2_First_Person_View_Enabled_Setting), false, Field::Hotkey, 0, 0, 0, "Down" },
+        
+
+        { (MGS2), ConfigKeys::MGS2_First_Person_View_Sticky_Section, ConfigKeys::MGS2_First_Person_View_Sticky_Setting, ConfigKeys::MGS2_First_Person_View_Sticky_Help, ConfigKeys::MGS2_First_Person_View_Sticky_Tooltip,
+          std::make_pair(ConfigKeys::MGS2_First_Person_View_Hold_Button_Section, ConfigKeys::MGS2_First_Person_View_Hold_Button_Setting), false, Field::Bool, false },
 
 
 

--- a/src/features/mgs2_first_person_view_mode.cpp
+++ b/src/features/mgs2_first_person_view_mode.cpp
@@ -266,7 +266,7 @@ void MGS2_First_Person_View::Activate()
 
     // Resume FPV automatically, changing rcx here will make the game update the camera functions all by itself
     if (bFirst_Person_View_Sticky) {
-        MAKE_HOOK_MID(baseModule, "3B C1 74 ?? 89 05", "MGS 2: FPV - user\sonoyama\raiden\event.c -> CheckWatch() inline @ l68 | Fix FPV Automatic Activation", {
+        MAKE_HOOK_MID(baseModule, "3B C1 74 ?? 89 05", "MGS 2: FPV - user\\sonoyama\\raiden\\event.c -> CheckWatch() inline @ l68 | Fix FPV Automatic Activation", {
             if (*gBP_1stPersonCamera_Active)
             {
                 ctx.rcx = *gBP_1stPersonCamera_Movement_Active;

--- a/src/features/mgs2_first_person_view_mode.cpp
+++ b/src/features/mgs2_first_person_view_mode.cpp
@@ -266,7 +266,7 @@ void MGS2_First_Person_View::Activate()
 
     // Resume FPV automatically, changing rcx here will make the game update the camera functions all by itself
     if (bFirst_Person_View_Sticky) {
-        MAKE_HOOK_MID(baseModule, "3B C1 74 52 89 05", "Fix FPV Automatic Activation", {
+        MAKE_HOOK_MID(baseModule, "3B C1 74 ?? 89 05", "MGS 2: FPV - user\sonoyama\raiden\event.c -> CheckWatch() inline @ l68 | Fix FPV Automatic Activation", {
             if (*gBP_1stPersonCamera_Active)
             {
                 ctx.rcx = *gBP_1stPersonCamera_Movement_Active;

--- a/src/features/mgs2_first_person_view_mode.cpp
+++ b/src/features/mgs2_first_person_view_mode.cpp
@@ -14,6 +14,7 @@ namespace
     int* gBP_1stPersonCamera_Move = nullptr;             // is fpv movement enabled
     int* gBP_1stPersonCamera_Hold_Toggle = nullptr;             // is first person toggled on/off
     int* gBP_1stPersonCamera_Active = nullptr;             // currently in 3rd or 1st person. (cutscene detection?)
+    int* gBP_1stPersonCamera_Movement_Active = nullptr;  // Seems to control shooter mode movement. Funny results if active without gBP_1stPersonCamera_Active
 
     /*
 
@@ -32,6 +33,7 @@ namespace
 
     bool bCameraForcedDisabled = false;
     bool bPreviousOverrideState = false;
+    bool bPreviousActiveState = false;
 
     void ForceCameraDisabled()
     {
@@ -39,6 +41,7 @@ namespace
         {
             bCameraForcedDisabled = true;
             bPreviousOverrideState = *gBP_1stPersonCamera_Override;
+            bPreviousActiveState = *gBP_1stPersonCamera_Active;
             //spdlog::info("MGS2: First Person View Mode: Forcing camera disabled. Override: {}, Hold Toggle: {}, Movement: {}", bPreviousOverrideState, bPreviousHoldToggleState, bPreviousMoveState);
         }
         *gBP_1stPersonCamera_Override = false;
@@ -46,7 +49,13 @@ namespace
 
     void ReleaseCameraState()
     {
-        bCameraForcedDisabled = false;
+        if (bCameraForcedDisabled) {
+            bCameraForcedDisabled = false;
+            if (MGS2_First_Person_View::bFirst_Person_View_Sticky) {
+                *gBP_1stPersonCamera_Active = bPreviousActiveState;
+            }
+        }
+        // TODO: Should this be checking for bCameraForcedDisabled being active previously? I'm gating the bPreviousActiveState to that.
         *gBP_1stPersonCamera_Override = bPreviousOverrideState;
         //spdlog::info("MGS2: First Person View Mode: Camera state released. Override: {}, Hold Toggle: {}, Movement: {}", *gBP_1stPersonCamera_Override, *gBP_1stPersonCamera_Hold_Toggle, *gBP_1stPersonCamera_Move);
     }
@@ -221,6 +230,7 @@ void MGS2_First_Person_View::Activate()
 
     gBP_1stPersonCamera_Active = reinterpret_cast<int*>(Memory::GetRelativeOffset(gBP_1stPersonCamera_Active_scan + 2));
 
+    gBP_1stPersonCamera_Movement_Active = reinterpret_cast<int*>(Memory::GetRelativeOffset(gBP_1stPersonCamera_Move_scan + 8));
 
 
     MAKE_HOOK_MID(baseModule, "0F 84 ?? ?? ?? ?? 33 C9 E8 ?? ?? ?? ?? 39 6F", "NewDivingGoggles -> act()", {
@@ -253,5 +263,16 @@ void MGS2_First_Person_View::Activate()
     }
                   });
                   */
+
+    // Resume FPV automatically, changing rcx here will make the game update the camera functions all by itself
+    if (bFirst_Person_View_Sticky) {
+        MAKE_HOOK_MID(baseModule, "3B C1 74 52 89 05", "Fix FPV Automatic Activation", {
+            if (*gBP_1stPersonCamera_Active)
+            {
+                ctx.rcx = *gBP_1stPersonCamera_Movement_Active;
+            }
+        });
+    }
+
 
 }

--- a/src/features/mgs2_first_person_view_mode.hpp
+++ b/src/features/mgs2_first_person_view_mode.hpp
@@ -12,6 +12,7 @@ namespace MGS2_First_Person_View
     inline bool bFirst_Person_View_Enabled = false;
     inline bool bFirst_Person_View_Movement_Enabled_By_Default = true;
     inline bool bFirst_Person_View_Toggle_Hold = true;
+    inline bool bFirst_Person_View_Sticky = false;
 
     inline int vkToggle_First_Person_Override = 0;
     inline int vkToggle_Hold_First_Person_View = 0;

--- a/src/resources/config.cpp
+++ b/src/resources/config.cpp
@@ -1077,6 +1077,8 @@ void Config::Read()
     LOG_CONFIG(ConfigKeys::MGS2_First_Person_View_Hold_Button_Section, ConfigKeys::MGS2_First_Person_View_Hold_Button_Setting, MGS2_First_Person_View::bFirst_Person_View_Toggle_Hold);
     if (MGS2_First_Person_View::bFirst_Person_View_Toggle_Hold)
     {
+        ConfigHelper::getValue(ini, ConfigKeys::MGS2_First_Person_View_Sticky_Section, ConfigKeys::MGS2_First_Person_View_Sticky_Setting, MGS2_First_Person_View::bFirst_Person_View_Sticky);
+        LOG_CONFIG(ConfigKeys::MGS2_First_Person_View_Sticky_Section, ConfigKeys::MGS2_First_Person_View_Sticky_Setting, MGS2_First_Person_View::bFirst_Person_View_Sticky);
         InputHandler::GetKeybind(ini, ConfigKeys::MGS2_First_Person_View_Hold_ToggleKey_Section, ConfigKeys::MGS2_First_Person_View_Hold_ToggleKey_Setting, MGS2_First_Person_View::vkToggle_Hold_First_Person_View);
     }
 

--- a/src/resources/config_keys.hpp
+++ b/src/resources/config_keys.hpp
@@ -583,12 +583,15 @@ namespace ConfigKeys
     constexpr const char* MGS2_First_Person_View_Hold_Button_Help = "";
     constexpr const char* MGS2_First_Person_View_Hold_Button_Tooltip = "";
 
-
-
     constexpr const char* MGS2_First_Person_View_Hold_ToggleKey_Section = MGS2_First_Person_View_Enabled_Section;
     constexpr const char* MGS2_First_Person_View_Hold_ToggleKey_Setting = "Toggle Tap for First Person View";
     constexpr const char* MGS2_First_Person_View_Hold_ToggleKey_Help = "";
     constexpr const char* MGS2_First_Person_View_Hold_ToggleKey_Tooltip = "";
+
+    constexpr const char* MGS2_First_Person_View_Sticky_Section = MGS2_First_Person_View_Enabled_Section;
+    constexpr const char* MGS2_First_Person_View_Sticky_Setting = "Keep First Person View Across Rooms";
+    constexpr const char* MGS2_First_Person_View_Sticky_Help = "";
+    constexpr const char* MGS2_First_Person_View_Sticky_Tooltip = "";
 
 
     constexpr const char* MGS2_RestoreOriginalDifficulty_Solidus_Choking_Section = "Difficulty Restoration";


### PR DESCRIPTION
Lightly tested from the roof of Strut A through the Pliskin introduction cutscene. First person view remained active except during cutscenes, and successfully reactivated immediately after said cutscenes. I made the toggle dependent on the "Tap to Keep First Person View Active" checkbox, but I would not count on its behavior with First Person Shooter Mode disabled, either. I imagine we ideally simplify the available options in the section at some point when there's a better grasp of how to control the functionality.