### PR TITLE
MGS2: soft particles for the spray and dust puffs

### DIFF
--- a/ConfigTool/tab_data.cpp
+++ b/ConfigTool/tab_data.cpp
@@ -186,6 +186,9 @@ const std::vector<std::pair<wxString, std::vector<Field>>> kTabs = {
         { (MGS2), ConfigKeys::MGS2_Increase_Shadow_Resolution_Section, ConfigKeys::MGS2_Increase_Shadow_Resolution_Setting, ConfigKeys::MGS2_Increase_Shadow_Resolution_Help, ConfigKeys::MGS2_Increase_Shadow_Resolution_Tooltip,
           std::nullopt, false, Field::Bool, true },
 
+        { (MGS2), ConfigKeys::MGS2_SoftParticles_Section, ConfigKeys::MGS2_SoftParticles_Setting, ConfigKeys::MGS2_SoftParticles_Help, ConfigKeys::MGS2_SoftParticles_Tooltip,
+          std::nullopt, false, Field::Bool, true },
+
 
 
         { (MGS3), ConfigKeys::DistanceCullingGrassAlways_Section, ConfigKeys::DistanceCullingGrassAlways_Setting, ConfigKeys::DistanceCullingGrassAlways_Help, ConfigKeys::DistanceCullingGrassAlways_Tooltip,

--- a/MGSHDFix.vcxproj
+++ b/MGSHDFix.vcxproj
@@ -41,6 +41,7 @@
     <ClCompile Include="src\fixes\mgs2_scanline_scale.cpp" />
     <ClCompile Include="src\fixes\mgs2_soft_shadows.cpp" />
     <ClCompile Include="src\fixes\mgs2_tanker_fog.cpp" />
+    <ClCompile Include="src\fixes\mgs2_soft_particles.cpp" />
     <ClCompile Include="src\fixes\mgs2_thermal_goggles.cpp" />
     <ClCompile Include="src\features\cutscene_pausing.cpp" />
     <ClCompile Include="src\features\adjustable_captions.cpp" />
@@ -203,6 +204,7 @@
     <ClInclude Include="src\fixes\mgs2_scanline_scale.hpp" />
     <ClInclude Include="src\fixes\mgs2_soft_shadows.hpp" />
     <ClInclude Include="src\fixes\mgs2_tanker_fog.hpp" />
+    <ClInclude Include="src\fixes\mgs2_soft_particles.hpp" />
     <ClInclude Include="src\fixes\mgs2_thermal_goggles.hpp" />
     <ClInclude Include="src\features\cutscene_pausing.hpp" />
     <ClInclude Include="src\resources\mgs2_status_flags.hpp" />

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -603,7 +603,6 @@ static void InitializeSubsystems()
         INITIALIZE(MGS2RotorProcession::Initialize());
         INITIALIZE(MGS2TankerSnakeSnap::Initialize());
         INITIALIZE(FixReverbWetLevel::Initialize());
-        INITIALIZE(MGS2RailgunBeam::InitializeEarly());
         INITIALIZE(MGS2DemoBlur::Initialize());
         INITIALIZE(MGS2FlareOcclusion::Initialize());
         INITIALIZE(CoolantMirrorFix::ApplyFix());

--- a/src/fixes/mgs2_railgun_beam.cpp
+++ b/src/fixes/mgs2_railgun_beam.cpp
@@ -2,6 +2,7 @@
 #include "mgs2_railgun_beam.hpp"
 
 #include "common.hpp"
+#include "d3d11_api.hpp"
 #include "logging.hpp"
 #include "gamevars.hpp"
 #include <d3d11.h>
@@ -12,34 +13,10 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
-    // Stock sprite vertex shader (Prim.fx SPRITE=1), identified by DXBC digest.
-    constexpr uint8_t kSpriteVSDigest[16] = {
-        0xB1, 0x03, 0x51, 0x1F, 0x89, 0xD7, 0x41, 0xB7, 0xAF, 0x31, 0x0C, 0xD9, 0x77, 0x2C, 0x24, 0x14 };
-    constexpr size_t kSpriteVSSize = 4544;
-
-    // Untextured prims bind an all-white stand-in and go through the doubling shader path; a 0x80 grey twin, substituted per draw for the effect shaders only, restores GS brightness.
-    constexpr uint8_t kPrimVSDigest[16] = {
-        0x92, 0x12, 0x98, 0xF1, 0x43, 0xBD, 0xE0, 0xFC, 0xBC, 0x66, 0xB2, 0xD2, 0x83, 0xD7, 0x14, 0x39 };
-    constexpr size_t kPrimVSSize = 4504;
-
     std::mutex g_standinMutex;
     std::set<ID3D11Resource*> g_standins;                 // live 4x4 white stand-in textures
-    ID3D11VertexShader* g_effectVS[16] = {};              // created instances of the effect shaders
-    int g_effectVSCount = 0;
     ComPtr<ID3D11Texture2D> g_greyTex;
     ComPtr<ID3D11ShaderResourceView> g_greySRV;
-
-    void RememberEffectVS(ID3D11VertexShader* vs)
-    {
-        if (vs && g_effectVSCount < 16) g_effectVS[g_effectVSCount++] = vs;
-    }
-
-    bool IsEffectVS(ID3D11VertexShader* vs)
-    {
-        for (int i = 0; i < g_effectVSCount; ++i)
-            if (g_effectVS[i] == vs) return true;
-        return false;
-    }
 
     bool EnsureGreyTwin(ID3D11Device* dev)
     {
@@ -57,9 +34,6 @@ namespace
     }
 
 
-    SafetyHookInline g_createDeviceHook {};
-    SafetyHookInline g_createDeviceSwapHook {};
-    SafetyHookInline g_createVSHook {};
     SafetyHookInline g_drawIndexedHook {};
 
 
@@ -69,11 +43,11 @@ namespace
     void STDMETHODCALLTYPE HookedDrawIndexed(ID3D11DeviceContext* ctx, UINT indexCount,
         UINT startIndex, INT baseVertex)
     {
-        if (g_greySRV && g_effectVSCount)
+        if (g_greySRV)
         {
             ComPtr<ID3D11VertexShader> vs;
             ctx->VSGetShader(vs.GetAddressOf(), nullptr, nullptr);
-            if (vs && IsEffectVS(vs.Get()))
+            if (vs && (D3D11Hooks::IsStockSpriteVS(vs.Get()) || D3D11Hooks::IsStockPrimVS(vs.Get())))
             {
                 ComPtr<ID3D11ShaderResourceView> srv;
                 ctx->PSGetShaderResources(0, 1, srv.GetAddressOf());
@@ -134,89 +108,20 @@ namespace
         }
         g_updateSubHook.stdcall<void>(ctx, dst, subresource, box, data, rowPitch, depthPitch);
     }
-
-    HRESULT STDMETHODCALLTYPE HookedCreateVertexShader(ID3D11Device* dev, const void* bytecode,
-        SIZE_T length, ID3D11ClassLinkage* linkage, ID3D11VertexShader** out)
-    {
-        const HRESULT hr = g_createVSHook.stdcall<HRESULT>(dev, bytecode, length, linkage, out);
-        if (SUCCEEDED(hr) && bytecode && out && *out &&
-            ((length == kSpriteVSSize && memcmp(static_cast<const uint8_t*>(bytecode) + 4, kSpriteVSDigest, 16) == 0) ||
-             (length == kPrimVSSize && memcmp(static_cast<const uint8_t*>(bytecode) + 4, kPrimVSDigest, 16) == 0)))
-        {
-            RememberEffectVS(*out);
-        }
-        return hr;
-    }
-
-
-    void HookDevice(ID3D11Device* dev)
-    {
-        if (g_createVSHook || !dev) return;
-        void** vtable = *reinterpret_cast<void***>(dev);
-        g_createVSHook = safetyhook::create_inline(vtable[12], reinterpret_cast<void*>(HookedCreateVertexShader));
-        LOG_HOOK(g_createVSHook, "MGS 2: Untextured prim brightness: CreateVertexShader");
-
-        EnsureGreyTwin(dev);
-
-        ComPtr<ID3D11DeviceContext> immCtx;
-        dev->GetImmediateContext(immCtx.GetAddressOf());
-        if (immCtx && !g_updateSubHook)
-        {
-            void** icvt = *reinterpret_cast<void***>(immCtx.Get());
-            g_updateSubHook = safetyhook::create_inline(icvt[48], reinterpret_cast<void*>(HookedUpdateSubresource));
-            LOG_HOOK(g_updateSubHook, "MGS 2: Untextured prim stand-in: UpdateSubresource");
-        }
-
-        ComPtr<ID3D11DeviceContext> ctx;
-        dev->GetImmediateContext(ctx.GetAddressOf());
-        if (ctx && !g_drawIndexedHook)
-        {
-            void** cvt = *reinterpret_cast<void***>(ctx.Get());
-            g_drawIndexedHook = safetyhook::create_inline(cvt[12], reinterpret_cast<void*>(HookedDrawIndexed));
-            LOG_HOOK(g_drawIndexedHook, "MGS 2: Missing-texture effect skip: DrawIndexed");
-        }
-    }
-
-    HRESULT WINAPI HookedD3D11CreateDevice(IDXGIAdapter* adapter, D3D_DRIVER_TYPE driverType,
-        HMODULE software, UINT flags, const D3D_FEATURE_LEVEL* levels, UINT numLevels, UINT sdkVersion,
-        ID3D11Device** dev, D3D_FEATURE_LEVEL* level, ID3D11DeviceContext** ctx)
-    {
-        const HRESULT hr = g_createDeviceHook.stdcall<HRESULT>(adapter, driverType, software, flags,
-            levels, numLevels, sdkVersion, dev, level, ctx);
-        if (SUCCEEDED(hr) && dev && *dev) HookDevice(*dev);
-        return hr;
-    }
-
-    HRESULT WINAPI HookedD3D11CreateDeviceAndSwapChain(IDXGIAdapter* adapter, D3D_DRIVER_TYPE driverType,
-        HMODULE software, UINT flags, const D3D_FEATURE_LEVEL* levels, UINT numLevels, UINT sdkVersion,
-        const DXGI_SWAP_CHAIN_DESC* scDesc, IDXGISwapChain** swap, ID3D11Device** dev,
-        D3D_FEATURE_LEVEL* level, ID3D11DeviceContext** ctx)
-    {
-        const HRESULT hr = g_createDeviceSwapHook.stdcall<HRESULT>(adapter, driverType, software, flags,
-            levels, numLevels, sdkVersion, scDesc, swap, dev, level, ctx);
-        if (SUCCEEDED(hr) && dev && *dev) HookDevice(*dev);
-        return hr;
-    }
 }
 
-void MGS2RailgunBeam::InitializeEarly()
+void MGS2RailgunBeam::OnDeviceCreated(ID3D11Device* dev)
 {
-    if (!(eGameType & MGS2) || !bEnabled) return;
+    if (!(eGameType & MGS2) || !bEnabled || !dev || g_drawIndexedHook) return;
 
-    HMODULE d3d11 = LoadLibraryW(L"d3d11.dll");
-    if (!d3d11)
-    {
-        spdlog::error("MGS 2: Untextured prim brightness: d3d11.dll not found.");
-        return;
-    }
-    if (auto* p = GetProcAddress(d3d11, "D3D11CreateDevice"))
-    {
-        g_createDeviceHook = safetyhook::create_inline(p, reinterpret_cast<void*>(HookedD3D11CreateDevice));
-        LOG_HOOK(g_createDeviceHook, "MGS 2: Untextured prim brightness: D3D11CreateDevice");
-    }
-    if (auto* p = GetProcAddress(d3d11, "D3D11CreateDeviceAndSwapChain"))
-    {
-        g_createDeviceSwapHook = safetyhook::create_inline(p, reinterpret_cast<void*>(HookedD3D11CreateDeviceAndSwapChain));
-        LOG_HOOK(g_createDeviceSwapHook, "MGS 2: Untextured prim brightness: D3D11CreateDeviceAndSwapChain");
-    }
+    EnsureGreyTwin(dev);
+
+    ComPtr<ID3D11DeviceContext> ctx;
+    dev->GetImmediateContext(ctx.GetAddressOf());
+    if (!ctx) return;
+    void** cvt = *reinterpret_cast<void***>(ctx.Get());
+    g_updateSubHook = safetyhook::create_inline(cvt[48], reinterpret_cast<void*>(HookedUpdateSubresource));
+    LOG_HOOK(g_updateSubHook, "MGS 2: Untextured prim stand-in: UpdateSubresource");
+    g_drawIndexedHook = safetyhook::create_inline(cvt[12], reinterpret_cast<void*>(HookedDrawIndexed));
+    LOG_HOOK(g_drawIndexedHook, "MGS 2: Missing-texture effect skip: DrawIndexed");
 }

--- a/src/fixes/mgs2_railgun_beam.hpp
+++ b/src/fixes/mgs2_railgun_beam.hpp
@@ -4,7 +4,7 @@
 // shader path, twice as bright as the GS. Substitutes a mid-grey twin for effect draws.
 namespace MGS2RailgunBeam
 {
-    void InitializeEarly();   // hooks D3D11 device creation - call at dll load, before the game boots
+    void OnDeviceCreated(ID3D11Device* dev);   // d3d11_api calls this as the game creates its device
 
     inline bool bEnabled = true;
 

--- a/src/fixes/mgs2_soft_particles.cpp
+++ b/src/fixes/mgs2_soft_particles.cpp
@@ -1,0 +1,224 @@
+#include "stdafx.h"
+
+#include "mgs2_soft_particles.hpp"
+#include "common.hpp"
+#include "d3d11_api.hpp"
+#include "logging.hpp"
+#include "scene_depth.hpp"
+
+#include <atomic>
+#include <mutex>
+#include <vector>
+
+// Big spray puffs sitting on the water get cut along a hard line by the z-test. Soft particles:
+// fade each pixel by how far the scene sits behind it, scaled to the sprite's own radius.
+
+namespace
+{
+    // splash03_alp, splash05_alp (user\morita\splash\splash.c); bombgas6_alp (user\okajima\effect\bomb_gas.c)
+    constexpr uint64_t kSoftTextures[] = { 0x13de2bb7654dd64eull, 0x29e8ce42c45836c5ull, 0x812baf1662a8d98cull };
+    constexpr UINT kTextureSize = 64;
+
+    // Prim.fx's sprite path, plus the sprite's true half-size in TEXCOORD0.z for the fade.
+    const char* kShader = R"(
+    static const float kFadeRadius = 0.5;   // fade span as a fraction of the half-size
+
+    cbuffer Globals : register(b0) { float4 c[25]; }
+    Texture2D        tex        : register(t0);
+    Texture2D<float> sceneDepth : register(t1);
+    SamplerState     samp       : register(s0);
+
+    struct VSIn { float3 pos : POSITION; int4 uvdxdy : TEXCOORD0; float4 col : TEXCOORD1; };
+    struct PSIn { float4 pos : SV_Position; float3 uv : TEXCOORD0; float4 col : TEXCOORD1; };
+
+    PSIn VS(VSIn i)
+    {
+        PSIn o;
+        float4 p = float4(i.pos, 1.0);
+        float4 s = float4(dot(c[16], p), dot(c[17], p), dot(c[18], p), dot(c[19], p));
+        s.xy += float2(i.uvdxdy.zw);
+        o.pos = float4(dot(c[20], s), dot(c[21], s), dot(c[22], s), dot(c[23], s));
+        o.uv.xy = float2(i.uvdxdy.xy) * c[24].xy / 4096.0 + c[24].zw;
+        // A scaled custom world shrinks the whole view vector, so the half-size comes back out by w.
+        o.uv.z = max(abs(float(i.uvdxdy.z)), abs(float(i.uvdxdy.w))) / s.w;
+        o.col = i.col * 2.0;
+        return o;
+    }
+
+    float LinearZ(float d) { return c[22].w / (d - c[22].z); }
+
+    float4 PS(PSIn i) : SV_Target
+    {
+        float4 o = saturate(tex.Sample(samp, i.uv.xy) * i.col) * float4(1, 1, 1, 2);
+        float d = sceneDepth.Load(int3(i.pos.xy, 0));
+        o.a *= saturate((LinearZ(d) - LinearZ(i.pos.z)) / (i.uv.z * kFadeRadius));
+        return o;
+    }
+    )";
+
+    std::mutex gLock;
+    std::vector<ComPtr<ID3D11Resource>> gTextures;   // held, so a freed one can never lend its address
+    std::atomic<bool> gArmed{ false };
+
+    SafetyHookInline gDrawIndexedHook{};
+    SafetyHookInline gUpdateSubHook{};
+    ComPtr<ID3D11VertexShader> gVS;
+    ComPtr<ID3D11PixelShader> gPS;
+    bool gShaderFailed = false;
+    uint64_t gDepthFrame = UINT64_MAX;
+
+    bool IsSoftTexture(const D3D11_TEXTURE2D_DESC& desc, const void* data, UINT rowPitch)
+    {
+        if (desc.Width != kTextureSize || desc.Height != kTextureSize || rowPitch < kTextureSize * 4
+            || (desc.Format != DXGI_FORMAT_B8G8R8A8_UNORM && desc.Format != DXGI_FORMAT_R8G8B8A8_UNORM))
+        {
+            return false;
+        }
+        const uint64_t hash = Util::HashTexels(data, rowPitch, kTextureSize, kTextureSize);
+        for (const uint64_t known : kSoftTextures)
+        {
+            if (hash == known)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void STDMETHODCALLTYPE HookedUpdateSubresource(ID3D11DeviceContext* ctx, ID3D11Resource* dst,
+        UINT subresource, const D3D11_BOX* box, const void* data, UINT rowPitch, UINT depthPitch)
+    {
+        ComPtr<ID3D11Texture2D> tex;
+        if (dst && data && !box && subresource == 0 && SUCCEEDED(dst->QueryInterface(IID_PPV_ARGS(tex.GetAddressOf()))))
+        {
+            D3D11_TEXTURE2D_DESC desc{};
+            tex->GetDesc(&desc);
+            if (IsSoftTexture(desc, data, rowPitch))
+            {
+                const std::lock_guard<std::mutex> guard(gLock);
+                gTextures.emplace_back(dst);
+                gArmed.store(true, std::memory_order_relaxed);
+            }
+        }
+        gUpdateSubHook.stdcall<void>(ctx, dst, subresource, box, data, rowPitch, depthPitch);
+    }
+
+    bool BoundToSoftTexture(ID3D11DeviceContext* ctx)
+    {
+        ComPtr<ID3D11ShaderResourceView> srv;
+        ctx->PSGetShaderResources(0, 1, srv.GetAddressOf());
+        ComPtr<ID3D11Resource> res;
+        if (srv)
+        {
+            srv->GetResource(res.GetAddressOf());
+        }
+        const std::lock_guard<std::mutex> guard(gLock);
+        for (const auto& tracked : gTextures)
+        {
+            if (tracked.Get() == res.Get())
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool EnsureShaders()
+    {
+        if (gVS && gPS)
+        {
+            return true;
+        }
+        auto* dev = g_D3D11Hooks.d3dDevice.Get();
+        auto compile = g_D3D11Hooks.D3DCompileFunc;
+        ComPtr<ID3DBlob> vs, ps, err;
+        if (gShaderFailed || !dev || !compile
+            || FAILED(compile(kShader, strlen(kShader), nullptr, nullptr, nullptr, "VS", "vs_5_0", 0, 0, vs.GetAddressOf(), err.GetAddressOf()))
+            || FAILED(compile(kShader, strlen(kShader), nullptr, nullptr, nullptr, "PS", "ps_5_0", 0, 0, ps.GetAddressOf(), err.ReleaseAndGetAddressOf()))
+            || FAILED(dev->CreateVertexShader(vs->GetBufferPointer(), vs->GetBufferSize(), nullptr, gVS.GetAddressOf()))
+            || FAILED(dev->CreatePixelShader(ps->GetBufferPointer(), ps->GetBufferSize(), nullptr, gPS.GetAddressOf())))
+        {
+            if (!gShaderFailed)
+            {
+                spdlog::error("MGS2SoftParticles: shader setup failed: {}",
+                    err ? static_cast<const char*>(err->GetBufferPointer()) : "no compiler");
+            }
+            gShaderFailed = true;
+            return false;
+        }
+        return true;
+    }
+
+    // One copy per frame: the puffs draw after everything that writes depth.
+    ID3D11ShaderResourceView* SceneDepthForFrame(ID3D11DeviceContext* ctx)
+    {
+        if (gDepthFrame != g_D3D11Hooks.FrameCount)
+        {
+            gDepthFrame = g_D3D11Hooks.FrameCount;
+            ComPtr<ID3D11DepthStencilView> dsv;
+            ctx->OMGetRenderTargets(0, nullptr, dsv.GetAddressOf());
+            SceneDepth::CaptureDepth(dsv.Get());
+        }
+        return SceneDepth::GetSRV();
+    }
+
+    void STDMETHODCALLTYPE HookedDrawIndexed(ID3D11DeviceContext* ctx, UINT indexCount, UINT startIndex,
+        INT baseVertex)
+    {
+        // Poly prims share the textures; only the sprite layout carries dx/dy.
+        ComPtr<ID3D11VertexShader> theirVS;
+        if (gArmed.load(std::memory_order_relaxed) && indexCount % 6 == 0)
+        {
+            ctx->VSGetShader(theirVS.GetAddressOf(), nullptr, nullptr);
+        }
+        ID3D11ShaderResourceView* depth = nullptr;
+        if (!theirVS || !D3D11Hooks::IsStockSpriteVS(theirVS.Get()) || !BoundToSoftTexture(ctx)
+            || !(depth = SceneDepthForFrame(ctx)) || !EnsureShaders())
+        {
+            gDrawIndexedHook.stdcall<void>(ctx, indexCount, startIndex, baseVertex);
+            return;
+        }
+
+        ComPtr<ID3D11PixelShader> theirPS;
+        ComPtr<ID3D11ShaderResourceView> theirSlot1;
+        ctx->PSGetShader(theirPS.GetAddressOf(), nullptr, nullptr);
+        ctx->PSGetShaderResources(1, 1, theirSlot1.GetAddressOf());
+
+        ctx->VSSetShader(gVS.Get(), nullptr, 0);
+        ctx->PSSetShader(gPS.Get(), nullptr, 0);
+        ctx->PSSetShaderResources(1, 1, &depth);
+        gDrawIndexedHook.stdcall<void>(ctx, indexCount, startIndex, baseVertex);
+        ID3D11ShaderResourceView* restore = theirSlot1.Get();
+        ctx->PSSetShaderResources(1, 1, &restore);
+        ctx->VSSetShader(theirVS.Get(), nullptr, 0);
+        ctx->PSSetShader(theirPS.Get(), nullptr, 0);
+
+        static bool logged = false;
+        if (!logged)
+        {
+            logged = true;
+            spdlog::info("MGS2SoftParticles: soft spray active.");
+        }
+    }
+}
+
+void MGS2SoftParticles::OnDeviceReady()
+{
+    if (!(eGameType & MGS2) || !bEnabled)
+    {
+        return;
+    }
+
+    auto* ctx = g_D3D11Hooks.d3dDeviceContext.Get();
+    if (!ctx)
+    {
+        spdlog::error("MGS2SoftParticles: no device context.");
+        return;
+    }
+
+    void** vtable = *reinterpret_cast<void***>(ctx);
+    gDrawIndexedHook = safetyhook::create_inline(vtable[12], reinterpret_cast<void*>(HookedDrawIndexed));
+    gUpdateSubHook = safetyhook::create_inline(vtable[48], reinterpret_cast<void*>(HookedUpdateSubresource));
+    LOG_HOOK(gDrawIndexedHook, "MGS 2: Soft particles: DrawIndexed");
+    LOG_HOOK(gUpdateSubHook, "MGS 2: Soft particles: UpdateSubresource");
+}

--- a/src/fixes/mgs2_soft_particles.hpp
+++ b/src/fixes/mgs2_soft_particles.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace MGS2SoftParticles
+{
+    inline bool bEnabled = true;
+    void OnDeviceReady();
+}

--- a/src/fixes/mgs2_tanker_fog.cpp
+++ b/src/fixes/mgs2_tanker_fog.cpp
@@ -99,17 +99,7 @@ namespace
             return false;
         }
 
-        // FNV-1a: seed with its 64-bit offset basis, then xor each byte in and multiply by its prime.
-        uint64_t hash = 0xcbf29ce484222325ull;
-        for (UINT y = 0; y < desc.Height; y++)
-        {
-            const auto* row = static_cast<const uint8_t*>(data) + static_cast<size_t>(y) * rowPitch;
-            for (UINT b = 0; b < desc.Width * 4; b++)
-            {
-                hash = (hash ^ row[b]) * 0x100000001b3ull;
-            }
-        }
-        return hash == kFogMaskHash;
+        return Util::HashTexels(data, rowPitch, desc.Width, desc.Height) == kFogMaskHash;
     }
 
     // The camera only reaches us through the constants the game maps every pass.

--- a/src/resources/config.cpp
+++ b/src/resources/config.cpp
@@ -21,6 +21,7 @@
 #include "mgs2_demo_camera_judder.hpp"
 #include "mgs2_codec_band.hpp"
 #include "mgs2_tanker_fog.hpp"
+#include "mgs2_soft_particles.hpp"
 #include "mgs2_demo_effect_blacklist.hpp"
 #include "mgs2_reverb_wet_level.hpp"
 #include "mgs2_preshade_lights.hpp"
@@ -487,6 +488,9 @@ void Config::Read()
     ConfigHelper::getValue(ini, ConfigKeys::MGS2_Increase_Shadow_Resolution_Section, ConfigKeys::MGS2_Increase_Shadow_Resolution_Setting, ResolutionScalingFixes::bIncreaseShadowResolution);
     LOG_CONFIG(ConfigKeys::MGS2_Increase_Shadow_Resolution_Section, ConfigKeys::MGS2_Increase_Shadow_Resolution_Setting, ResolutionScalingFixes::bIncreaseShadowResolution);
     MGS2SoftShadows::bEnabled = ResolutionScalingFixes::bIncreaseShadowResolution;
+
+    ConfigHelper::getValue(ini, ConfigKeys::MGS2_SoftParticles_Section, ConfigKeys::MGS2_SoftParticles_Setting, MGS2SoftParticles::bEnabled);
+    LOG_CONFIG(ConfigKeys::MGS2_SoftParticles_Section, ConfigKeys::MGS2_SoftParticles_Setting, MGS2SoftParticles::bEnabled);
 
 
     ConfigHelper::getValue(ini, ConfigKeys::MGS2_LaserOriginFix_FixM9FPV_Section, ConfigKeys::MGS2_LaserOriginFix_FixM9FPV_Setting, ResolutionScalingFixes::bFixM92FPV);

--- a/src/resources/config_keys.hpp
+++ b/src/resources/config_keys.hpp
@@ -335,6 +335,13 @@ namespace ConfigKeys
         "\n"
         "This option makes shadow resolution scale dynamically with the game's internal resolution.";
 
+    constexpr const char* MGS2_SoftParticles_Section = "Model Quality && Level of Detail Enhancements";
+    constexpr const char* MGS2_SoftParticles_Setting = "Show Soft Particles";
+    constexpr const char* MGS2_SoftParticles_Help = "";
+    constexpr const char* MGS2_SoftParticles_Tooltip = "Spray and dust puffs are flat sprites, so they cut off along a hard line wherever they pass through water or ground.\n"
+        "\n"
+        "This option fades them out against nearby surfaces instead.";
+
     constexpr const char* MGS2_LaserOriginFix_FixM9FPV_Section = "Bugfixes";
     constexpr const char* MGS2_LaserOriginFix_FixM9FPV_Setting = "Fix M92 Laser Origin in FPV";
     constexpr const char* MGS2_LaserOriginFix_FixM9FPV_Help = "";

--- a/src/resources/d3d11_api.cpp
+++ b/src/resources/d3d11_api.cpp
@@ -19,6 +19,8 @@
 #include "mgs2_first_person_view_mode.hpp"
 #include "mgs2_thermal_goggles.hpp"
 #include "mgs2_tanker_fog.hpp"
+#include "mgs2_soft_particles.hpp"
+#include "mgs2_railgun_beam.hpp"
 #include "mgs2_underwater_filter.hpp"
 #include "mgs2_demo_blur.hpp"
 #include "mgs2_gas_haze.hpp"
@@ -51,6 +53,80 @@ namespace
 
     using ResizeBuffersFn = HRESULT(__stdcall*)(IDXGISwapChain*, UINT, UINT, UINT, DXGI_FORMAT, UINT);
     ResizeBuffersFn oResizeBuffers = nullptr;
+
+    // Stock Prim.fx vertex shaders, told apart by DXBC digest as the game creates them.
+    constexpr uint8_t kSpriteVSDigest[16] = {
+        0xB1, 0x03, 0x51, 0x1F, 0x89, 0xD7, 0x41, 0xB7, 0xAF, 0x31, 0x0C, 0xD9, 0x77, 0x2C, 0x24, 0x14 };
+    constexpr size_t kSpriteVSSize = 4544;
+    constexpr uint8_t kPrimVSDigest[16] = {
+        0x92, 0x12, 0x98, 0xF1, 0x43, 0xBD, 0xE0, 0xFC, 0xBC, 0x66, 0xB2, 0xD2, 0x83, 0xD7, 0x14, 0x39 };
+    constexpr size_t kPrimVSSize = 4504;
+
+    struct StockVS { ID3D11VertexShader* vs; bool sprite; };
+    StockVS g_stockVS[16] {};
+    int g_stockVSCount = 0;
+
+    SafetyHookInline g_createDeviceHook {};
+    SafetyHookInline g_createDeviceSwapHook {};
+    SafetyHookInline g_createVSHook {};
+
+    HRESULT STDMETHODCALLTYPE HookedCreateVertexShader(ID3D11Device* dev, const void* bytecode,
+        SIZE_T length, ID3D11ClassLinkage* linkage, ID3D11VertexShader** out)
+    {
+        const HRESULT hr = g_createVSHook.stdcall<HRESULT>(dev, bytecode, length, linkage, out);
+        if (SUCCEEDED(hr) && bytecode && out && *out && g_stockVSCount < static_cast<int>(std::size(g_stockVS)))
+        {
+            const uint8_t* digest = static_cast<const uint8_t*>(bytecode) + 4;
+            if (length == kSpriteVSSize && memcmp(digest, kSpriteVSDigest, 16) == 0)
+            {
+                g_stockVS[g_stockVSCount++] = { *out, true };
+            }
+            else if (length == kPrimVSSize && memcmp(digest, kPrimVSDigest, 16) == 0)
+            {
+                g_stockVS[g_stockVSCount++] = { *out, false };
+            }
+        }
+        return hr;
+    }
+
+    void OnDeviceCreated(ID3D11Device* dev)
+    {
+        if (!dev || g_createVSHook)
+        {
+            return;
+        }
+        void** vtable = *reinterpret_cast<void***>(dev);
+        g_createVSHook = safetyhook::create_inline(vtable[12], reinterpret_cast<void*>(HookedCreateVertexShader));
+        LOG_HOOK(g_createVSHook, "D3D11Hooks: CreateVertexShader");
+        MGS2RailgunBeam::OnDeviceCreated(dev);
+    }
+
+    HRESULT WINAPI HookedD3D11CreateDevice(IDXGIAdapter* adapter, D3D_DRIVER_TYPE driverType,
+        HMODULE software, UINT flags, const D3D_FEATURE_LEVEL* levels, UINT numLevels, UINT sdkVersion,
+        ID3D11Device** dev, D3D_FEATURE_LEVEL* level, ID3D11DeviceContext** ctx)
+    {
+        const HRESULT hr = g_createDeviceHook.stdcall<HRESULT>(adapter, driverType, software, flags,
+            levels, numLevels, sdkVersion, dev, level, ctx);
+        if (SUCCEEDED(hr) && dev)
+        {
+            OnDeviceCreated(*dev);
+        }
+        return hr;
+    }
+
+    HRESULT WINAPI HookedD3D11CreateDeviceAndSwapChain(IDXGIAdapter* adapter, D3D_DRIVER_TYPE driverType,
+        HMODULE software, UINT flags, const D3D_FEATURE_LEVEL* levels, UINT numLevels, UINT sdkVersion,
+        const DXGI_SWAP_CHAIN_DESC* scDesc, IDXGISwapChain** swap, ID3D11Device** dev,
+        D3D_FEATURE_LEVEL* level, ID3D11DeviceContext** ctx)
+    {
+        const HRESULT hr = g_createDeviceSwapHook.stdcall<HRESULT>(adapter, driverType, software, flags,
+            levels, numLevels, sdkVersion, scDesc, swap, dev, level, ctx);
+        if (SUCCEEDED(hr) && dev)
+        {
+            OnDeviceCreated(*dev);
+        }
+        return hr;
+    }
 
     // The PS2 never presented a frame it hadn't drawn; the port does, and it flashes dim.
     ComPtr<ID3D11Texture2D> g_heldFrame;
@@ -296,6 +372,7 @@ namespace
             MGS3MapRelight::OnDeviceReady();
             MGS3GlowOverbright::OnDeviceReady(g_D3D11Hooks.d3dDevice.Get());
             MGS2TankerFog::OnDeviceReady();
+            MGS2SoftParticles::OnDeviceReady();
             if (eGameType & (MGS2 | MGS3))
             {
                 // Drop redundant IA state changes - the games re-set layout/topology per draw.
@@ -472,6 +549,20 @@ void D3D11Hooks::Initialize()
 
     if (eGameType & MGS2)
     {
+        if (const HMODULE d3d11 = LoadLibraryW(L"d3d11.dll"))
+        {
+            if (auto* p = GetProcAddress(d3d11, "D3D11CreateDevice"))
+            {
+                g_createDeviceHook = safetyhook::create_inline(p, reinterpret_cast<void*>(HookedD3D11CreateDevice));
+                LOG_HOOK(g_createDeviceHook, "D3D11Hooks: D3D11CreateDevice");
+            }
+            if (auto* p = GetProcAddress(d3d11, "D3D11CreateDeviceAndSwapChain"))
+            {
+                g_createDeviceSwapHook = safetyhook::create_inline(p, reinterpret_cast<void*>(HookedD3D11CreateDeviceAndSwapChain));
+                LOG_HOOK(g_createDeviceSwapHook, "D3D11Hooks: D3D11CreateDeviceAndSwapChain");
+            }
+        }
+
         constexpr uint32_t kDG_DMAPACK_NORMAL = 0x0001;
         constexpr uint32_t kDG_DMAPACK_MENU = 0x0002;
         MAKE_HOOK_MID(baseModule, "40 55 57 41 56 48 8D AC 24 40 FC FF FF 48 81 EC C0 04 00 00 48 8B F9", "D3D11 Hooks: BP_RenderDmaPack_AutoPacket", {
@@ -502,4 +593,28 @@ void D3D11Hooks::Initialize()
     {
         return;
     }*/
+}
+
+bool D3D11Hooks::IsStockSpriteVS(ID3D11VertexShader* vs)
+{
+    for (int i = 0; i < g_stockVSCount; i++)
+    {
+        if (g_stockVS[i].vs == vs)
+        {
+            return g_stockVS[i].sprite;
+        }
+    }
+    return false;
+}
+
+bool D3D11Hooks::IsStockPrimVS(ID3D11VertexShader* vs)
+{
+    for (int i = 0; i < g_stockVSCount; i++)
+    {
+        if (g_stockVS[i].vs == vs)
+        {
+            return !g_stockVS[i].sprite;
+        }
+    }
+    return false;
 }

--- a/src/resources/d3d11_api.hpp
+++ b/src/resources/d3d11_api.hpp
@@ -7,6 +7,10 @@ class D3D11Hooks final
 public:
     static void Initialize();
 
+    // Stock Prim.fx vertex shaders, caught as the game creates them.
+    static bool IsStockSpriteVS(ID3D11VertexShader* vs);   // SPRITE=1
+    static bool IsStockPrimVS(ID3D11VertexShader* vs);     // the untextured prim path
+
     HWND MainHwnd = nullptr;
 
     // ===================== Device and Context =====================

--- a/src/resources/helper.hpp
+++ b/src/resources/helper.hpp
@@ -118,6 +118,21 @@ namespace Util
 
     bool IsFileReadOnly(const std::filesystem::path& path);
 
+    // FNV-1a over the texel rows of an RGBA8 upload.
+    inline uint64_t HashTexels(const void* data, size_t rowPitch, unsigned width, unsigned height)
+    {
+        uint64_t hash = 0xcbf29ce484222325ull;
+        for (unsigned y = 0; y < height; y++)
+        {
+            const auto* row = static_cast<const uint8_t*>(data) + static_cast<size_t>(y) * rowPitch;
+            for (unsigned b = 0; b < width * 4; b++)
+            {
+                hash = (hash ^ row[b]) * 0x100000001b3ull;
+            }
+        }
+        return hash;
+    }
+
     bool IsJapanese();
 
 

--- a/src/resources/scene_depth.cpp
+++ b/src/resources/scene_depth.cpp
@@ -92,7 +92,7 @@ namespace
         D3D11_TEXTURE2D_DESC sd {};
         src->GetDesc(&sd);
         DXGI_FORMAT typeless, srvFmt;
-        if (!MapDepthFormat(sd.Format, typeless, srvFmt))
+        if (sd.SampleDesc.Count > 1 || !MapDepthFormat(sd.Format, typeless, srvFmt))
         {
             return false;
         }


### PR DESCRIPTION
Not a high pressure feature by any means, but something I noticed from day 1! Adds a new setting for zdepth tested particles which I was inspired by https://game.watch.impress.co.jp/docs/20081204/3dmg4.htm It's kept quite narrow, mostly because I haven't seen this happen in many places, but can be added to the texture list.

Cleaned up shared code for hashing + added D3D Vertex helpers which are used in other effects already.